### PR TITLE
Update of subgrid-scale cloud physics for MYNN/GF

### DIFF
--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -172,10 +172,10 @@ elif [[ $MACHINE_ID = hera.* ]]; then
   QUEUE=debug
 #  ACCNR=fv3-cpu
   PARTITION=
-  dprefix=/scratch1/BMC/gmtb
-  DISKNM=$dprefix/ufs-weather-model/RT
-  STMP=$dprefix
-  PTMP=$dprefix
+  dprefix=/scratch1/NCEPDEV
+  DISKNM=$dprefix/nems/emc.nemspara/RT
+  STMP=$dprefix/stmp4
+  PTMP=$dprefix/stmp2
 
   # default scheduler on Hera
   SCHEDULER=slurm


### PR DESCRIPTION
This PR updates the submodule pointer for FV3 for the code changes described in https://github.com/NOAA-GSD/fv3atm/pull/3 and https://github.com/NOAA-GSD/ccpp-physics/pull/2. It also reverts a DTC-specific change to `tests/rt.sh` (location of regression test baseline).

Associated PRs:
https://github.com/NOAA-GSD/ccpp-physics/pull/2
https://github.com/NOAA-GSD/fv3atm/pull/3
https://github.com/NOAA-GSD/ufs-weather-model/pull/2

See https://github.com/NOAA-GSD/fv3atm/pull/3 for regression testing information.