### PR TITLE
Update for "Changes in cloud/radiation interaction in GSD physics suite", non-aerosol-aware Thompson MP tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-GSD/fv3atm
-	branch = gsd/develop
+	url = https://github.com/climbfuji/fv3atm
+	branch = gsd-dev-clouds_thompson-no-aero_dom
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/climbfuji/fv3atm
-	branch = gsd-dev-clouds_thompson-no-aero_dom
+	url = https://github.com/NOAA-GSD/fv3atm
+	branch = gsd/develop
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/tests/fv3_conf/ccpp_gsd_run.IN
+++ b/tests/fv3_conf/ccpp_gsd_run.IN
@@ -27,10 +27,19 @@ fi
 
 # Copy field table, depending on microphysics choice and whether MYNN/SATMEDMF is used
 if [ $IMP_PHYSICS = 8 ]; then
-  if [ $DO_MYNNEDMF = .T. ] || [ $SATMEDMF = .T. ]; then
-    cp  @[RTPWD]/FV3_input_data_gsd/field_table_gsd field_table
+  if [ $LTAEROSOL = .T. ]; then
+    if [ $DO_MYNNEDMF = .T. ] || [ $SATMEDMF = .T. ]; then
+      cp  @[RTPWD]/FV3_input_data_gsd/field_table_gsd field_table
+    else
+      cp  @[RTPWD]/FV3_input_data_gsd/field_table_gf_thompson field_table
+    fi
   else
-    cp  @[RTPWD]/FV3_input_data_gsd/field_table_gf_thompson field_table
+    if [ $DO_MYNNEDMF = .T. ] || [ $SATMEDMF = .T. ]; then
+      echo "ERROR, no field table configured for Thompson MP without aerosols but with MYNN or SATMEDMF (need TKE)"
+      exit 1
+    else
+      cp  /scratch1/BMC/gmtb/ufs-weather-model/RT/NEMSfv3gfs/FV3_input_data_temporary_thompson_noaero/field_table_thompson_noaero field_table
+    fi
   fi
 elif [ $IMP_PHYSICS = 11 ]; then
   if [ $DO_MYNNEDMF = .T. ] || [ $SATMEDMF = .T. ]; then

--- a/tests/rt_ccpp_gsd.conf
+++ b/tests/rt_ccpp_gsd.conf
@@ -18,16 +18,20 @@ COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_v15_thompson,FV3_GFS_v15_gf,FV3
 COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_v15_thompson,FV3_GFS_v15_gf,FV3_GFS_v15_mynn,FV3_GSD_v0_drag_suite,FV3_GSD_SAR| standard    | cheyenne.gnu   | fv3         |
 # Run tests
 RUN     | fv3_ccpp_thompson                                                                                                    | standard    |                | fv3         |
+# Non-aerosol field_table staged only on hera for the moment
+RUN     | fv3_ccpp_thompson_no_aero                                                                                            | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_gf                                                                                                          | standard    |                | fv3         |
 RUN     | fv3_ccpp_mynn                                                                                                        | standard    |                | fv3         |
 RUN     | fv3_ccpp_gsd_drag_suite                                                                                              | standard    |                | fv3         |
 RUN     | fv3_ccpp_gsd_sar                                                                                                     | standard    |                | fv3         |
 # Compile with CCPP - static mode, debug
-COMPILE | CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_v0                                                                            | standard    | hera.intel     | fv3         |
-COMPILE | CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_v0                                                                            | standard    | cheyenne.intel | fv3         |
-COMPILE | CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_v0                                                                            | standard    | cheyenne.gnu   | fv3         |
+COMPILE | CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson                                                       | standard    | hera.intel     | fv3         |
+COMPILE | CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson                                                       | standard    | cheyenne.intel | fv3         |
+COMPILE | CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_v0,FV3_GFS_v15_thompson                                                       | standard    | cheyenne.gnu   | fv3         |
 # Run tests
 RUN     | fv3_ccpp_gsd_debug                                                                                                   | standard    |                | fv3         |
+# Non-aerosol field_table staged only on hera for the moment
+RUN     | fv3_ccpp_thompson_no_aero_debug                                                                                      | standard    | hera.intel     | fv3         |
 # Compile with CCPP - static mode, debug, 32bit dynamics
 COMPILE | 32BIT=Y CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_SAR                                                                   | standard    | hera.intel     | fv3         |
 COMPILE | 32BIT=Y CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_SAR                                                                   | standard    | cheyenne.intel | fv3         |

--- a/tests/tests/fv3_ccpp_thompson_no_aero
+++ b/tests/tests/fv3_ccpp_thompson_no_aero
@@ -1,0 +1,94 @@
+###############################################################################
+#
+#  FV3 CCPP Thompson MP without aerosols test
+#
+###############################################################################
+
+export TEST_DESCR="Compare FV3 CCPP Thompson MP without aerosols results with previous trunk version"
+
+export CNTL_DIR=fv3_thompson_no_aero
+
+export LIST_FILES="atmos_4xdaily.tile1.nc \
+                   atmos_4xdaily.tile2.nc \
+                   atmos_4xdaily.tile3.nc \
+                   atmos_4xdaily.tile4.nc \
+                   atmos_4xdaily.tile5.nc \
+                   atmos_4xdaily.tile6.nc \
+                   phyf000.tile1.nc \
+                   phyf000.tile2.nc \
+                   phyf000.tile3.nc \
+                   phyf000.tile4.nc \
+                   phyf000.tile5.nc \
+                   phyf000.tile6.nc \
+                   phyf024.tile1.nc \
+                   phyf024.tile2.nc \
+                   phyf024.tile3.nc \
+                   phyf024.tile4.nc \
+                   phyf024.tile5.nc \
+                   phyf024.tile6.nc \
+                   dynf000.tile1.nc \
+                   dynf000.tile2.nc \
+                   dynf000.tile3.nc \
+                   dynf000.tile4.nc \
+                   dynf000.tile5.nc \
+                   dynf000.tile6.nc \
+                   dynf024.tile1.nc \
+                   dynf024.tile2.nc \
+                   dynf024.tile3.nc \
+                   dynf024.tile4.nc \
+                   dynf024.tile5.nc \
+                   dynf024.tile6.nc \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc"
+
+export_fv3
+export NODES=$(expr $TASKS / $TPN + 1)
+
+export DT_ATMOS="600"
+export IMP_PHYSICS=8
+export DNATS=0
+export DO_SAT_ADJ=.F.
+export LRADAR=.T.
+export LTAEROSOL=.F.
+
+export FV3_RUN=ccpp_gsd_run.IN
+export CCPP_SUITE=FV3_GFS_v15_thompson
+export CCPP_LIB_DIR=ccpp/lib
+export INPUT_NML=ccpp_gsd.nml.IN
+
+export HYBEDMF=.T.
+export DO_MYNNEDMF=.F.
+export IMFSHALCNV=2
+export IMFDEEPCNV=2
+
+RUN_SCRIPT=rt_fv3.sh

--- a/tests/tests/fv3_ccpp_thompson_no_aero_debug
+++ b/tests/tests/fv3_ccpp_thompson_no_aero_debug
@@ -1,0 +1,97 @@
+###############################################################################
+#
+#  FV3 CCPP Thompson MP without aerosols debug test
+#
+###############################################################################
+
+export TEST_DESCR="Compare FV3 CCPP Thompson MP without aerosols debug results with previous trunk version"
+
+export CNTL_DIR=fv3_thompson_no_aero_debug
+
+export LIST_FILES="atmos_4xdaily.tile1.nc \
+                   atmos_4xdaily.tile2.nc \
+                   atmos_4xdaily.tile3.nc \
+                   atmos_4xdaily.tile4.nc \
+                   atmos_4xdaily.tile5.nc \
+                   atmos_4xdaily.tile6.nc \
+                   phyf000.tile1.nc \
+                   phyf000.tile2.nc \
+                   phyf000.tile3.nc \
+                   phyf000.tile4.nc \
+                   phyf000.tile5.nc \
+                   phyf000.tile6.nc \
+                   phyf006.tile1.nc \
+                   phyf006.tile2.nc \
+                   phyf006.tile3.nc \
+                   phyf006.tile4.nc \
+                   phyf006.tile5.nc \
+                   phyf006.tile6.nc \
+                   dynf000.tile1.nc \
+                   dynf000.tile2.nc \
+                   dynf000.tile3.nc \
+                   dynf000.tile4.nc \
+                   dynf000.tile5.nc \
+                   dynf000.tile6.nc \
+                   dynf006.tile1.nc \
+                   dynf006.tile2.nc \
+                   dynf006.tile3.nc \
+                   dynf006.tile4.nc \
+                   dynf006.tile5.nc \
+                   dynf006.tile6.nc \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc"
+
+export_fv3
+export NODES=$(expr $TASKS / $TPN + 1)
+
+export FHMAX=6
+export FDIAG=3
+
+export DT_ATMOS="600"
+export IMP_PHYSICS=8
+export DNATS=0
+export DO_SAT_ADJ=.F.
+export LRADAR=.T.
+export LTAEROSOL=.F.
+
+export FV3_RUN=ccpp_gsd_run.IN
+export CCPP_SUITE=FV3_GFS_v15_thompson
+export CCPP_LIB_DIR=ccpp/lib
+export INPUT_NML=ccpp_gsd.nml.IN
+
+export HYBEDMF=.T.
+export DO_MYNNEDMF=.F.
+export IMFSHALCNV=2
+export IMFDEEPCNV=2
+
+RUN_SCRIPT=rt_fv3.sh


### PR DESCRIPTION
This PR:
- adds regression tests for the non-aerosol-aware Thompson MP option
- contains changes in cloud/radiation interaction in GSD physics suite in FV3 and ccpp-physics from @tanyasmirnova

Associated PRs:
https://github.com/NOAA-GSD/ccpp-physics/pull/16
https://github.com/NOAA-GSD/fv3atm/pull/13
https://github.com/NOAA-GSD/ufs-weather-model/pull/11

See below for regression testing information.