### PR TITLE
gsd/develop: handle blocked data structures in init and finalize routines, remove pset logic, metadata cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NOAA-GSD/fv3atm
-	#branch = gsd/develop
-	url = https://github.com/climbfuji/fv3atm
-	branch = gsd_develop_blocked_data_structures
+	url = https://github.com/NOAA-GSD/fv3atm
+	branch = gsd/develop
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-GSD/fv3atm
-	branch = gsd/develop
+	#url = https://github.com/NOAA-GSD/fv3atm
+	#branch = gsd/develop
+	url = https://github.com/climbfuji/fv3atm
+	branch = gsd_develop_blocked_data_structures
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/tests/rt_ccpp_gsd.conf
+++ b/tests/rt_ccpp_gsd.conf
@@ -1,51 +1,51 @@
-#############################################################################################################################################################################
-# CCPP STATIC tests                                                                                                                                                         #
-#############################################################################################################################################################################
+#################################################################################################################################################################################
+# CCPP STATIC tests                                                                                                                                                             #
+#################################################################################################################################################################################
 # Compile with CCPP - static mode
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_gf_thompson,FV3_GSD_v0,FV3_GSD_noah             | standard    | hera.intel     | fv3         |
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_gf_thompson,FV3_GSD_v0,FV3_GSD_noah             | standard    | cheyenne.intel | fv3         |
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_gf_thompson,FV3_GSD_v0,FV3_GSD_noah             | standard    | cheyenne.gnu   | fv3         |
+COMPILE | CCPP=Y REPRO=Y SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_gf_thompson,FV3_GSD_v0,FV3_GSD_noah                          | standard    | hera.intel     | fv3         |
+COMPILE | CCPP=Y REPRO=Y SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_gf_thompson,FV3_GSD_v0,FV3_GSD_noah                          | standard    | cheyenne.intel | fv3         |
+COMPILE | CCPP=Y REPRO=Y SUITES=FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_gf_thompson,FV3_GSD_v0,FV3_GSD_noah                          | standard    | cheyenne.gnu   | fv3         |
 # Run tests
-RUN     | fv3_ccpp_thompson_mynn                                                                                               | standard    |                | fv3         |
-RUN     | fv3_ccpp_gf_thompson                                                                                                 | standard    |                | fv3         |
-RUN     | fv3_ccpp_gsd                                                                                                         | standard    |                | fv3         |
-RUN     | fv3_ccpp_gsd_coldstart                                                                                               | standard    |                |             |
-RUN     | fv3_ccpp_gsd_warmstart                                                                                               | standard    |                |             | fv3_ccpp_gsd_coldstart
-RUN     | fv3_ccpp_gsd_noah                                                                                                    | standard    |                | fv3         |
+RUN     | fv3_ccpp_thompson_mynn                                                                                                   | standard    |                | fv3         |
+RUN     | fv3_ccpp_gf_thompson                                                                                                     | standard    |                | fv3         |
+RUN     | fv3_ccpp_gsd                                                                                                             | standard    |                | fv3         |
+RUN     | fv3_ccpp_gsd_coldstart                                                                                                   | standard    |                |             |
+RUN     | fv3_ccpp_gsd_warmstart                                                                                                   | standard    |                |             | fv3_ccpp_gsd_coldstart
+RUN     | fv3_ccpp_gsd_noah                                                                                                        | standard    |                | fv3         |
 # Compile with CCPP - static mode
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc                                               | standard    | hera.intel     | fv3         |
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc                                               | standard    | cheyenne.intel | fv3         |
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc                                               | standard    | cheyenne.gnu   | fv3         |
+COMPILE | CCPP=Y REPRO=Y SUITES=FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc                                                            | standard    | hera.intel     | fv3         |
+COMPILE | CCPP=Y REPRO=Y SUITES=FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc                                                            | standard    | cheyenne.intel | fv3         |
+COMPILE | CCPP=Y REPRO=Y SUITES=FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc                                                            | standard    | cheyenne.gnu   | fv3         |
 # Run tests
-RUN     | fv3_ccpp_gsd_mynnsfc                                                                                                 | standard    |                | fv3         |
-RUN     | fv3_ccpp_gsd_noah_mynnsfc                                                                                            | standard    |                | fv3         |
+RUN     | fv3_ccpp_gsd_mynnsfc                                                                                                     | standard    |                | fv3         |
+RUN     | fv3_ccpp_gsd_noah_mynnsfc                                                                                                | standard    |                | fv3         |
 # Compile with CCPP - static mode
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_v15_thompson,FV3_GFS_v15_gf,FV3_GFS_v15_mynn,FV3_GSD_v0_drag_suite,FV3_GSD_SAR,FV3_RAPHRRR | standard    | hera.intel     | fv3         |
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_v15_thompson,FV3_GFS_v15_gf,FV3_GFS_v15_mynn,FV3_GSD_v0_drag_suite,FV3_GSD_SAR,FV3_RAPHRRR | standard    | cheyenne.intel | fv3         |
-COMPILE | CCPP=Y REPRO=Y STATIC=Y SUITES=FV3_GFS_v15_thompson,FV3_GFS_v15_gf,FV3_GFS_v15_mynn,FV3_GSD_v0_drag_suite,FV3_GSD_SAR,FV3_RAPHRRR | standard    | cheyenne.gnu   | fv3         |
+COMPILE | CCPP=Y REPRO=Y SUITES=FV3_GFS_v15_thompson,FV3_GFS_v15_gf,FV3_GFS_v15_mynn,FV3_GSD_v0_drag_suite,FV3_GSD_SAR,FV3_RAPHRRR | standard    | hera.intel     | fv3         |
+COMPILE | CCPP=Y REPRO=Y SUITES=FV3_GFS_v15_thompson,FV3_GFS_v15_gf,FV3_GFS_v15_mynn,FV3_GSD_v0_drag_suite,FV3_GSD_SAR,FV3_RAPHRRR | standard    | cheyenne.intel | fv3         |
+COMPILE | CCPP=Y REPRO=Y SUITES=FV3_GFS_v15_thompson,FV3_GFS_v15_gf,FV3_GFS_v15_mynn,FV3_GSD_v0_drag_suite,FV3_GSD_SAR,FV3_RAPHRRR | standard    | cheyenne.gnu   | fv3         |
 # Run tests
-RUN     | fv3_ccpp_thompson                                                                                                    | standard    |                | fv3         |
+RUN     | fv3_ccpp_thompson                                                                                                        | standard    |                | fv3         |
 # Non-aerosol field_table staged only on hera for the moment
-RUN     | fv3_ccpp_thompson_no_aero                                                                                            | standard    | hera.intel     | fv3         |
-RUN     | fv3_ccpp_gf                                                                                                          | standard    |                | fv3         |
-RUN     | fv3_ccpp_mynn                                                                                                        | standard    |                | fv3         |
-RUN     | fv3_ccpp_gsd_drag_suite                                                                                              | standard    |                | fv3         |
-RUN     | fv3_ccpp_gsd_sar                                                                                                     | standard    |                | fv3         |
-RUN     | fv3_ccpp_raphrrr                                                                                                     | standard    |                | fv3         |
+RUN     | fv3_ccpp_thompson_no_aero                                                                                                | standard    | hera.intel     | fv3         |
+RUN     | fv3_ccpp_gf                                                                                                              | standard    |                | fv3         |
+RUN     | fv3_ccpp_mynn                                                                                                            | standard    |                | fv3         |
+RUN     | fv3_ccpp_gsd_drag_suite                                                                                                  | standard    |                | fv3         |
+RUN     | fv3_ccpp_gsd_sar                                                                                                         | standard    |                | fv3         |
+RUN     | fv3_ccpp_raphrrr                                                                                                         | standard    |                | fv3         |
 # Compile with CCPP - static mode, debug
-COMPILE | CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_v0,FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc,FV3_GFS_v15_thompson               | standard    | hera.intel     | fv3         |
-COMPILE | CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_v0,FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc,FV3_GFS_v15_thompson               | standard    | cheyenne.intel | fv3         |
-COMPILE | CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_v0,FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc,FV3_GFS_v15_thompson               | standard    | cheyenne.gnu   | fv3         |
+COMPILE | CCPP=Y DEBUG=Y SUITES=FV3_GSD_v0,FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc,FV3_GFS_v15_thompson                            | standard    | hera.intel     | fv3         |
+COMPILE | CCPP=Y DEBUG=Y SUITES=FV3_GSD_v0,FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc,FV3_GFS_v15_thompson                            | standard    | cheyenne.intel | fv3         |
+COMPILE | CCPP=Y DEBUG=Y SUITES=FV3_GSD_v0,FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc,FV3_GFS_v15_thompson                            | standard    | cheyenne.gnu   | fv3         |
 # Run tests
-RUN     | fv3_ccpp_gsd_debug                                                                                                   | standard    |                | fv3         |
-RUN     | fv3_ccpp_gsd_diag3d_debug                                                                                            | standard    |                | fv3         |
-RUN     | fv3_ccpp_gsd_mynnsfc_debug                                                                                           | standard    |                | fv3         |
-RUN     | fv3_ccpp_gsd_noah_mynnsfc_debug                                                                                      | standard    |                | fv3         |
+RUN     | fv3_ccpp_gsd_debug                                                                                                       | standard    |                | fv3         |
+RUN     | fv3_ccpp_gsd_diag3d_debug                                                                                                | standard    |                | fv3         |
+RUN     | fv3_ccpp_gsd_mynnsfc_debug                                                                                               | standard    |                | fv3         |
+RUN     | fv3_ccpp_gsd_noah_mynnsfc_debug                                                                                          | standard    |                | fv3         |
 # Non-aerosol field_table staged only on hera for the moment
-RUN     | fv3_ccpp_thompson_no_aero_debug                                                                                      | standard    | hera.intel     | fv3         |
+RUN     | fv3_ccpp_thompson_no_aero_debug                                                                                          | standard    | hera.intel     | fv3         |
 # Compile with CCPP - static mode, debug, 32bit dynamics
-COMPILE | 32BIT=Y CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_SAR,FV3_RAPHRRR                                                       | standard    | hera.intel     | fv3         |
-COMPILE | 32BIT=Y CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_SAR,FV3_RAPHRRR                                                       | standard    | cheyenne.intel | fv3         |
-COMPILE | 32BIT=Y CCPP=Y DEBUG=Y STATIC=Y SUITES=FV3_GSD_SAR,FV3_RAPHRRR                                                       | standard    | cheyenne.gnu   | fv3         |
+COMPILE | 32BIT=Y CCPP=Y DEBUG=Y SUITES=FV3_GSD_SAR,FV3_RAPHRRR                                                                    | standard    | hera.intel     | fv3         |
+COMPILE | 32BIT=Y CCPP=Y DEBUG=Y SUITES=FV3_GSD_SAR,FV3_RAPHRRR                                                                    | standard    | cheyenne.intel | fv3         |
+COMPILE | 32BIT=Y CCPP=Y DEBUG=Y SUITES=FV3_GSD_SAR,FV3_RAPHRRR                                                                    | standard    | cheyenne.gnu   | fv3         |
 # Run tests
-RUN     | fv3_ccpp_gsd_sar_25km_debug                                                                                          | standard    |                | fv3         |
+RUN     | fv3_ccpp_gsd_sar_25km_debug                                                                                              | standard    |                | fv3         |


### PR DESCRIPTION
Changes in this PR:
- update submodule pointer for fv3atm

Associated PRs:

https://github.com/NOAA-GSD/ccpp-framework/pull/4
https://github.com/NOAA-GSD/ccpp-physics/pull/29
https://github.com/NOAA-GSD/fv3atm/pull/30
https://github.com/NOAA-GSD/ufs-weather-model/pull/23

For regression testing information, see below.