### PR TITLE
Option to roll back Thompson MP to WRFv3.8.1 (RAPv5/HRRRv4), add stochastic perturbations code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NOAA-GSD/fv3atm
-	#branch = gsd/develop
-	url = https://github.com/climbfuji/fv3atm
-	branch = rollback_thompson
+	url = https://github.com/NOAA-GSD/fv3atm
+	branch = gsd/develop
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-GSD/fv3atm
-	branch = gsd/develop
+	#url = https://github.com/NOAA-GSD/fv3atm
+	#branch = gsd/develop
+	url = https://github.com/climbfuji/fv3atm
+	branch = rollback_thompson
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/modulefiles/hera.gnu/fv3
+++ b/modulefiles/hera.gnu/fv3
@@ -15,7 +15,8 @@ setenv NCEPLIBS /scratch2/NCEPDEV/nwprod/NCEPLIBS
 ## load contrib environment
 ## load slurm utils (arbitrary.pl  layout.pl)
 ##
-module load contrib sutils
+module use -a /contrib/sutils/modulefiles
+module load sutils
 
 ##
 ## load programming environment

--- a/modulefiles/hera.intel/fv3
+++ b/modulefiles/hera.intel/fv3
@@ -15,7 +15,8 @@ setenv NCEPLIBS /scratch2/NCEPDEV/nwprod/NCEPLIBS
 ## load contrib environment
 ## load slurm utils (arbitrary.pl  layout.pl)
 ##
-module load contrib sutils
+module use -a /contrib/sutils/modulefiles
+module load sutils
 
 ##
 ## load programming environment

--- a/modulefiles/jet.intel/fv3
+++ b/modulefiles/jet.intel/fv3
@@ -13,7 +13,8 @@ module purge
 ## load contrib environment
 ## load slurm utils (arbitrary.pl  layout.pl)
 ##
-module load contrib sutils
+module use -a /contrib/sutils/modulefiles
+module load sutils
 
 module load intel/18.0.5.274
 module load impi/2018.4.274


### PR DESCRIPTION
This PR only updates the submodule pointer for fv3atm.

Associated PRs:
https://github.com/NOAA-GSD/ccpp-physics/pull/34
https://github.com/NOAA-GSD/fv3atm/pull/35
https://github.com/NOAA-GSD/ufs-weather-model/pull/28

For regression testing information, see below.