### PR TITLE
Enable subsurface cycling (fhcyc) for regression tests using RUC LSM and other GSL physics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	#url = https://github.com/NOAA-GSD/fv3atm
-	#branch = gsd/develop
-	url = https://github.com/climbfuji/fv3atm
-	branch = pretty_print_sfcsub
+	url = https://github.com/NOAA-GSD/fv3atm
+	branch = gsd/develop
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-GSD/fv3atm
-	branch = gsd/develop
+	#url = https://github.com/NOAA-GSD/fv3atm
+	#branch = gsd/develop
+	url = https://github.com/climbfuji/fv3atm
+	branch = pretty_print_sfcsub
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/parm/ccpp_gsd_sar.nml.IN
+++ b/parm/ccpp_gsd_sar.nml.IN
@@ -141,7 +141,7 @@
        fhzero         = 6.
        h2o_phys       = .true.
        ldiag3d        = .false.
-       fhcyc          = 0
+       fhcyc          = @[FHCYC]
        nst_anl        = .true.
        use_ufo        = .true.
        pre_rad        = .false.

--- a/parm/ccpp_gsd_sar_25km.nml.IN
+++ b/parm/ccpp_gsd_sar_25km.nml.IN
@@ -141,7 +141,7 @@
      fhzero         = 1.
      h2o_phys       = .true.
      ldiag3d        = .false.
-     fhcyc          = 0.
+     fhcyc          = @[FHCYC]
      nst_anl        = .true.
      use_ufo        = .true.
      pre_rad        = .false.

--- a/tests/tests/fv3_ccpp_gsd
+++ b/tests/tests/fv3_ccpp_gsd
@@ -117,7 +117,6 @@ export HYBEDMF=.F.
 export DO_MYNNEDMF=.T.
 export IMFSHALCNV=3
 export IMFDEEPCNV=3
-export FHCYC=0
 export LSM=3
 export LSOIL_LSM=9
 

--- a/tests/tests/fv3_ccpp_gsd_coldstart
+++ b/tests/tests/fv3_ccpp_gsd_coldstart
@@ -55,7 +55,6 @@ export HYBEDMF=.F.
 export DO_MYNNEDMF=.T.
 export IMFSHALCNV=3
 export IMFDEEPCNV=3
-export FHCYC=0
 export LSM=3
 export LSOIL_LSM=9
 

--- a/tests/tests/fv3_ccpp_gsd_debug
+++ b/tests/tests/fv3_ccpp_gsd_debug
@@ -93,7 +93,6 @@ export HYBEDMF=.F.
 export DO_MYNNEDMF=.T.
 export IMFSHALCNV=3
 export IMFDEEPCNV=3
-export FHCYC=0
 export LSM=3
 export LSOIL_LSM=9
 

--- a/tests/tests/fv3_ccpp_gsd_diag3d_debug
+++ b/tests/tests/fv3_ccpp_gsd_diag3d_debug
@@ -97,7 +97,6 @@ export HYBEDMF=.F.
 export DO_MYNNEDMF=.T.
 export IMFSHALCNV=3
 export IMFDEEPCNV=3
-export FHCYC=0
 export LSM=3
 export LSOIL_LSM=9
 

--- a/tests/tests/fv3_ccpp_gsd_drag_suite
+++ b/tests/tests/fv3_ccpp_gsd_drag_suite
@@ -93,7 +93,6 @@ export HYBEDMF=.F.
 export DO_MYNNEDMF=.T.
 export IMFSHALCNV=3
 export IMFDEEPCNV=3
-export FHCYC=0
 export LSM=3
 export LSOIL_LSM=9
 export GWD_OPT=3

--- a/tests/tests/fv3_ccpp_gsd_mynnsfc
+++ b/tests/tests/fv3_ccpp_gsd_mynnsfc
@@ -118,7 +118,6 @@ export DO_MYNNEDMF=.T.
 export DO_MYNNSFCLAY=.T.
 export IMFSHALCNV=3
 export IMFDEEPCNV=3
-export FHCYC=0
 export LSM=3
 export LSOIL_LSM=9
 

--- a/tests/tests/fv3_ccpp_gsd_mynnsfc_debug
+++ b/tests/tests/fv3_ccpp_gsd_mynnsfc_debug
@@ -94,7 +94,6 @@ export DO_MYNNEDMF=.T.
 export DO_MYNNSFCLAY=.T.
 export IMFSHALCNV=3
 export IMFDEEPCNV=3
-export FHCYC=0
 export LSM=3
 export LSOIL_LSM=9
 

--- a/tests/tests/fv3_ccpp_gsd_noah
+++ b/tests/tests/fv3_ccpp_gsd_noah
@@ -117,7 +117,6 @@ export HYBEDMF=.F.
 export DO_MYNNEDMF=.T.
 export IMFSHALCNV=3
 export IMFDEEPCNV=3
-export FHCYC=0
 export LSM=1
 export LSOIL_LSM=4
 

--- a/tests/tests/fv3_ccpp_gsd_warmstart
+++ b/tests/tests/fv3_ccpp_gsd_warmstart
@@ -95,7 +95,6 @@ export HYBEDMF=.F.
 export DO_MYNNEDMF=.T.
 export IMFSHALCNV=3
 export IMFDEEPCNV=3
-export FHCYC=0
 export LSM=3
 export LSOIL_LSM=9
 

--- a/tests/tests/fv3_ccpp_hrrr
+++ b/tests/tests/fv3_ccpp_hrrr
@@ -94,7 +94,6 @@ export DO_MYNNEDMF=.T.
 export DO_MYNNSFCLAY=.T.
 export IMFSHALCNV=-1
 export IMFDEEPCNV=-1
-export FHCYC=0
 export LSM=3
 export LSOIL_LSM=9
 export GWD_OPT=3

--- a/tests/tests/fv3_ccpp_rap
+++ b/tests/tests/fv3_ccpp_rap
@@ -94,7 +94,6 @@ export DO_MYNNEDMF=.T.
 export DO_MYNNSFCLAY=.T.
 export IMFSHALCNV=3
 export IMFDEEPCNV=3
-export FHCYC=0
 export LSM=3
 export LSOIL_LSM=9
 export GWD_OPT=3

--- a/tests/tests/fv3_ccpp_rrfs_v1beta
+++ b/tests/tests/fv3_ccpp_rrfs_v1beta
@@ -117,7 +117,6 @@ export HYBEDMF=.F.
 export DO_MYNNEDMF=.T.
 export IMFSHALCNV=-1
 export IMFDEEPCNV=-1
-export FHCYC=0
 export LSM=2
 export LSOIL_LSM=4
 export GWD_OPT=3

--- a/tests/tests/fv3_ccpp_rrfs_v1beta_debug
+++ b/tests/tests/fv3_ccpp_rrfs_v1beta_debug
@@ -93,7 +93,6 @@ export HYBEDMF=.F.
 export DO_MYNNEDMF=.T.
 export IMFSHALCNV=-1
 export IMFDEEPCNV=-1
-export FHCYC=0
 export LSM=2
 export LSOIL_LSM=4
 export GWD_OPT=3


### PR DESCRIPTION
Changes in this PR:
- update `.gitmodules` and submodule pointer for fv3atm/ccpp-physics for pretty print in `physics/sfcsub.F`, no changes in fv3atm
- enable subsurface cycling (`fhcyc`) for regression tests using RUC LSM
- enable subsurface cycling for regression tests that should have it enabled (because using Noah or NoahMP), but didn't thus far

Associated PRs:

https://github.com/NOAA-GSD/ccpp-physics/pull/52
https://github.com/NOAA-GSD/fv3atm/pull/48
https://github.com/NOAA-GSD/ufs-weather-model/pull/40

For regression testing information, see below.