### PR TITLE
SPPT and CA perturbations of SO2 emissions + 2 regtests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/NOAA-GSD/fv3atm
+	url = https://github.com/SamuelTrahanNOAA/fv3atm
 	branch = gsd/develop-chem
 [submodule "NEMS"]
 	path = NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
 	url = https://github.com/SamuelTrahanNOAA/fv3atm
-	branch = gsd/develop-chem
+	branch = feature/v2-ca-pert-gbbepx
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/SamuelTrahanNOAA/fv3atm
-	branch = feature/v2-ca-pert-gbbepx
+	url = https://github.com/NOAA-GSL/fv3atm
+	branch = gsd/develop-chem
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS


### PR DESCRIPTION
SPPT and CA from stochastic physics are connected to SO2 emissions. This is only a proof of concept; other emission perturbations will be added later. There are two new regression tests, one for each perturbation method.

The `tests/rt.conf` is updated to only run chem regests on Hera since we have no baselines elsewhere.