### PR TITLE
RUC ice for gsl/develop (replaces #47)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-GSL/fv3atm
-  branch = gsl/develop
+  #url = https://github.com/NOAA-GSL/fv3atm
+  #branch = gsl/develop
+  url = https://github.com/climbfuji/fv3atm
+  branch = rucice_gsl_develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-GSL/fv3atm
-  #branch = gsl/develop
-  url = https://github.com/climbfuji/fv3atm
-  branch = rucice_gsl_develop
+  url = https://github.com/NOAA-GSL/fv3atm
+  branch = gsl/develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/tests/default_vars.sh
+++ b/tests/default_vars.sh
@@ -275,6 +275,7 @@ export DO_MYNNSFCLAY=.F.
 export LSM=1
 export LSOIL_LSM=4
 export LANDICE=.T.
+export KICE=2
 
 # Ozone / stratospheric H2O
 export OZ_PHYS_OLD=.T.

--- a/tests/parm/ccpp_gsd.nml.IN
+++ b/tests/parm/ccpp_gsd.nml.IN
@@ -176,6 +176,7 @@
        n_var_lndp     = @[N_VAR_LNDP]
        lsm            = @[LSM]
        lsoil_lsm      = @[LSOIL_LSM]
+       kice           = @[KICE]
        iopt_dveg      = 2
        iopt_crs       = 1
        iopt_btr       = 1

--- a/tests/parm/ccpp_gsd_sar.nml.IN
+++ b/tests/parm/ccpp_gsd_sar.nml.IN
@@ -199,6 +199,7 @@
      lsm            = 3
      lsoil          = 9
      lsoil_lsm      = 9
+     kice           = 9
      iopt_dveg      = 2
      iopt_crs       = 1
      iopt_btr       = 1

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -317,7 +317,7 @@ fi
 mkdir -p ${STMP}/${USER}
 
 # Different own baseline directories for different compilers on Theia/Cheyenne
-NEW_BASELINE=${STMP}/${USER}/FV3_RT/REGRESSION_TEST
+NEW_BASELINE=${STMP}/${USER}/FV3_RT/REGRESSION_TEST_GSL_DEVELOP
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]]; then
     NEW_BASELINE=${NEW_BASELINE}_${RT_COMPILER^^}
 fi

--- a/tests/tests/fv3_ccpp_gsd
+++ b/tests/tests/fv3_ccpp_gsd
@@ -118,7 +118,7 @@ export IMFSHALCNV=3
 export IMFDEEPCNV=3
 export LSM=3
 export LSOIL_LSM=9
-
+export KICE=9
 
 export WLCLK=30
 

--- a/tests/tests/fv3_ccpp_gsd_coldstart
+++ b/tests/tests/fv3_ccpp_gsd_coldstart
@@ -56,4 +56,4 @@ export IMFSHALCNV=3
 export IMFDEEPCNV=3
 export LSM=3
 export LSOIL_LSM=9
-
+export KICE=9

--- a/tests/tests/fv3_ccpp_gsd_debug
+++ b/tests/tests/fv3_ccpp_gsd_debug
@@ -94,6 +94,6 @@ export IMFSHALCNV=3
 export IMFDEEPCNV=3
 export LSM=3
 export LSOIL_LSM=9
-
+export KICE=9
 
 export WLCLK=30

--- a/tests/tests/fv3_ccpp_gsd_diag3d_debug
+++ b/tests/tests/fv3_ccpp_gsd_diag3d_debug
@@ -98,7 +98,7 @@ export IMFSHALCNV=3
 export IMFDEEPCNV=3
 export LSM=3
 export LSOIL_LSM=9
-
+export KICE=9
 
 export WLCLK=30
 

--- a/tests/tests/fv3_ccpp_gsd_drag_suite
+++ b/tests/tests/fv3_ccpp_gsd_drag_suite
@@ -94,6 +94,7 @@ export IMFSHALCNV=3
 export IMFDEEPCNV=3
 export LSM=3
 export LSOIL_LSM=9
+export KICE=9
 export GWD_OPT=3
 export DO_UGWP_V0=.F.
 export DO_UGWP_V0_OROG_ONLY=.F.

--- a/tests/tests/fv3_ccpp_gsd_drag_suite_unified_ugwp
+++ b/tests/tests/fv3_ccpp_gsd_drag_suite_unified_ugwp
@@ -94,6 +94,8 @@ export IMFSHALCNV=3
 export IMFDEEPCNV=3
 export LSM=3
 export LSOIL_LSM=9
+export KICE=9
+
 export GWD_OPT=2
 export DO_UGWP_V0=.F.
 export DO_UGWP_V0_OROG_ONLY=.F.

--- a/tests/tests/fv3_ccpp_gsd_mynnsfc
+++ b/tests/tests/fv3_ccpp_gsd_mynnsfc
@@ -120,6 +120,7 @@ export IMFSHALCNV=3
 export IMFDEEPCNV=3
 export LSM=3
 export LSOIL_LSM=9
+export KICE=9
 
 RUN_SCRIPT=rt_fv3.sh
 

--- a/tests/tests/fv3_ccpp_gsd_mynnsfc_debug
+++ b/tests/tests/fv3_ccpp_gsd_mynnsfc_debug
@@ -96,6 +96,7 @@ export IMFSHALCNV=3
 export IMFDEEPCNV=3
 export LSM=3
 export LSOIL_LSM=9
+export KICE=9
 
 RUN_SCRIPT=rt_fv3.sh
 

--- a/tests/tests/fv3_ccpp_gsd_unified_ugwp
+++ b/tests/tests/fv3_ccpp_gsd_unified_ugwp
@@ -118,6 +118,8 @@ export IMFSHALCNV=3
 export IMFDEEPCNV=3
 export LSM=3
 export LSOIL_LSM=9
+export KICE=9
+
 export GWD_OPT=2
 export DO_UGWP_V0=.T.
 export DO_UGWP_V0_OROG_ONLY=.F.

--- a/tests/tests/fv3_ccpp_gsd_warmstart
+++ b/tests/tests/fv3_ccpp_gsd_warmstart
@@ -96,4 +96,4 @@ export IMFSHALCNV=3
 export IMFDEEPCNV=3
 export LSM=3
 export LSOIL_LSM=9
-
+export KICE=9

--- a/tests/tests/fv3_ccpp_hrrr
+++ b/tests/tests/fv3_ccpp_hrrr
@@ -95,6 +95,8 @@ export IMFSHALCNV=-1
 export IMFDEEPCNV=-1
 export LSM=3
 export LSOIL_LSM=9
+export KICE=9
+
 export GWD_OPT=3
 export DO_UGWP_V0=.F.
 export DO_UGWP_V0_OROG_ONLY=.F.

--- a/tests/tests/fv3_ccpp_rap
+++ b/tests/tests/fv3_ccpp_rap
@@ -95,6 +95,8 @@ export IMFSHALCNV=3
 export IMFDEEPCNV=3
 export LSM=3
 export LSOIL_LSM=9
+export KICE=9
+
 export GWD_OPT=3
 export DO_UGWP_V0=.F.
 export DO_UGWP_V0_OROG_ONLY=.F.


### PR DESCRIPTION
This PR contains the necessary changes to the regression tests for the RUC ICE implementation in the PRs below.

Associated PRs:

https://github.com/NOAA-GSL/ccpp-physics/pull/65
https://github.com/NOAA-GSL/fv3atm/pull/60
https://github.com/NOAA-GSL/ufs-weather-model/pull/49

For regression testing information, see below.
