### PR TITLE
Land stochastic perturbations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-GSL/fv3atm
-  branch = gsl/develop
+  #url = https://github.com/NOAA-GSL/fv3atm
+  #branch = gsl/develop
+  url = https://github.com/climbfuji/fv3atm
+  branch = land-stoch-pert-dom
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-GSL/fv3atm
-  #branch = gsl/develop
-  url = https://github.com/climbfuji/fv3atm
-  branch = land-stoch-pert-dom
+  url = https://github.com/NOAA-GSL/fv3atm
+  branch = gsl/develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS
@@ -18,10 +16,8 @@
   branch = develop
 [submodule "stochastic_physics"]
   path = stochastic_physics
-  #url = https://github.com/noaa-gsl/stochastic_physics
-  #branch = gsl/develop
-  url = https://github.com/tanyasmirnova/stochastic_physics
-  branch = gsl_landstoch_withruc
+  url = https://github.com/noaa-gsl/stochastic_physics
+  branch = gsl/develop
 [submodule "CMakeModules"]
   path = CMakeModules
   url = https://github.com/NOAA-EMC/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,8 +18,10 @@
   branch = develop
 [submodule "stochastic_physics"]
   path = stochastic_physics
-  url = https://github.com/noaa-gsl/stochastic_physics
-  branch = gsl/develop
+  #url = https://github.com/noaa-gsl/stochastic_physics
+  #branch = gsl/develop
+  url = https://github.com/tanyasmirnova/stochastic_physics
+  branch = gsl_landstoch_withruc
 [submodule "CMakeModules"]
   path = CMakeModules
   url = https://github.com/NOAA-EMC/CMakeModules

--- a/tests/default_vars.sh
+++ b/tests/default_vars.sh
@@ -322,6 +322,7 @@ export DO_SHUM=.F.
 export DO_SKEB=.F.
 export LNDP_TYPE=0
 export N_VAR_LNDP=0
+export LNDP_EACH_STEP=.F.
 export SKEB=-999.
 export SPPT=-999.
 export SHUM=-999.

--- a/tests/parm/ccpp_gsd.nml.IN
+++ b/tests/parm/ccpp_gsd.nml.IN
@@ -174,6 +174,7 @@
        do_skeb        = @[DO_SKEB]
        lndp_type      = @[LNDP_TYPE]
        n_var_lndp     = @[N_VAR_LNDP]
+       lndp_each_step = @[LNDP_EACH_STEP]
        lsm            = @[LSM]
        lsoil_lsm      = @[LSOIL_LSM]
        kice           = @[KICE]

--- a/tests/parm/ccpp_gsd.nml.IN
+++ b/tests/parm/ccpp_gsd.nml.IN
@@ -325,6 +325,8 @@
   LNDP_TAU=21600,
   LNDP_LSCALE=500000,
   ISEED_LNDP=2010,
+  lndp_var_list = 'vgf','alb','sal'
+  lndp_prt_list = 0.02,0.01,0.01
 /
 
 &cires_ugwp_nml

--- a/tests/parm/ccpp_lndp.nml.IN
+++ b/tests/parm/ccpp_lndp.nml.IN
@@ -194,6 +194,7 @@
        do_skeb        = @[DO_SKEB]
        lndp_type      = @[LNDP_TYPE]
        n_var_lndp     = @[N_VAR_LNDP]
+       lndp_each_step = @[LNDP_EACH_STEP]
        do_ca          = .false.
        ca_sgs         = .false.
        nca            = 1

--- a/tests/rt_ccpp_dev.conf
+++ b/tests/rt_ccpp_dev.conf
@@ -9,7 +9,9 @@ RUN     | fv3_ccpp_gf_thompson                                                  
 RUN     | fv3_ccpp_gsd                                                                                                             | standard    |                | fv3         |
 RUN     | fv3_ccpp_gsd_coldstart                                                                                                   | standard    |                |             |
 RUN     | fv3_ccpp_gsd_warmstart                                                                                                   | standard    |                |             | fv3_ccpp_gsd_coldstart
+RUN     | fv3_ccpp_gsd_lndp                                                                                                        | standard    |                | fv3         |
 RUN     | fv3_ccpp_gsd_noah                                                                                                        | standard    |                | fv3         |
+RUN     | fv3_ccpp_gsd_noah_lndp                                                                                                   | standard    |                | fv3         |
 
 COMPILE | CCPP=Y REPRO=Y SUITES=FV3_GSD_v0_mynnsfc,FV3_GSD_noah_mynnsfc                                                            | standard    |                | fv3         |
 

--- a/tests/tests/fv3_ccpp_gsd_lndp
+++ b/tests/tests/fv3_ccpp_gsd_lndp
@@ -95,5 +95,6 @@ export KICE=9
 
 export LNDP_TYPE=2
 export N_VAR_LNDP=3
+export LNDP_EACH_STEP=.T.
 
 #export WLCLK=30

--- a/tests/tests/fv3_ccpp_gsd_lndp
+++ b/tests/tests/fv3_ccpp_gsd_lndp
@@ -1,0 +1,99 @@
+#########################################################################################
+#
+#  FV3 CCPP GSD (GF CU + Thompson MP + MYNN PBL + RUC LSM) with land stochastic pert test
+#
+#########################################################################################
+
+export TEST_DESCR="Compare FV3 CCPP GSD lndp results with previous trunk version"
+
+export CNTL_DIR=fv3_gsd_lndp
+
+export LIST_FILES="atmos_4xdaily.tile1.nc \
+                   atmos_4xdaily.tile2.nc \
+                   atmos_4xdaily.tile3.nc \
+                   atmos_4xdaily.tile4.nc \
+                   atmos_4xdaily.tile5.nc \
+                   atmos_4xdaily.tile6.nc \
+                   phyf000.tile1.nc \
+                   phyf000.tile2.nc \
+                   phyf000.tile3.nc \
+                   phyf000.tile4.nc \
+                   phyf000.tile5.nc \
+                   phyf000.tile6.nc \
+                   phyf024.tile1.nc \
+                   phyf024.tile2.nc \
+                   phyf024.tile3.nc \
+                   phyf024.tile4.nc \
+                   phyf024.tile5.nc \
+                   phyf024.tile6.nc \
+                   dynf000.tile1.nc \
+                   dynf000.tile2.nc \
+                   dynf000.tile3.nc \
+                   dynf000.tile4.nc \
+                   dynf000.tile5.nc \
+                   dynf000.tile6.nc \
+                   dynf024.tile1.nc \
+                   dynf024.tile2.nc \
+                   dynf024.tile3.nc \
+                   dynf024.tile4.nc \
+                   dynf024.tile5.nc \
+                   dynf024.tile6.nc \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc"
+
+export_fv3
+
+export DT_ATMOS="600"
+export IMP_PHYSICS=8
+export DNATS=0
+export DO_SAT_ADJ=.F.
+export LRADAR=.T.
+export LTAEROSOL=.T.
+
+export FV3_RUN=ccpp_gsd_run.IN
+export CCPP_SUITE=FV3_GSD_v0
+export CCPP_LIB_DIR=ccpp/lib
+export INPUT_NML=ccpp_gsd.nml.IN
+
+export HYBEDMF=.F.
+export DO_MYNNEDMF=.T.
+export IMFSHALCNV=3
+export IMFDEEPCNV=3
+export LSM=3
+export LSOIL_LSM=9
+export KICE=9
+
+export LNDP_TYPE=2
+export N_VAR_LNDP=3
+
+#export WLCLK=30

--- a/tests/tests/fv3_ccpp_gsd_noah_lndp
+++ b/tests/tests/fv3_ccpp_gsd_noah_lndp
@@ -94,5 +94,6 @@ export LSOIL_LSM=4
 
 export LNDP_TYPE=2
 export N_VAR_LNDP=3
+export LNDP_EACH_STEP=.T.
 
 #export WLCLK=30

--- a/tests/tests/fv3_ccpp_gsd_noah_lndp
+++ b/tests/tests/fv3_ccpp_gsd_noah_lndp
@@ -1,0 +1,98 @@
+##########################################################################################
+#
+#  FV3 CCPP GSD (GF CU + Thompson MP + MYNN PBL + NOAH LSM) with land stochastic pert test
+#
+##########################################################################################
+
+export TEST_DESCR="Compare FV3 CCPP GSD lndp results with previous trunk version"
+
+export CNTL_DIR=fv3_gsd_noah_lndp
+
+export LIST_FILES="atmos_4xdaily.tile1.nc \
+                   atmos_4xdaily.tile2.nc \
+                   atmos_4xdaily.tile3.nc \
+                   atmos_4xdaily.tile4.nc \
+                   atmos_4xdaily.tile5.nc \
+                   atmos_4xdaily.tile6.nc \
+                   phyf000.tile1.nc \
+                   phyf000.tile2.nc \
+                   phyf000.tile3.nc \
+                   phyf000.tile4.nc \
+                   phyf000.tile5.nc \
+                   phyf000.tile6.nc \
+                   phyf024.tile1.nc \
+                   phyf024.tile2.nc \
+                   phyf024.tile3.nc \
+                   phyf024.tile4.nc \
+                   phyf024.tile5.nc \
+                   phyf024.tile6.nc \
+                   dynf000.tile1.nc \
+                   dynf000.tile2.nc \
+                   dynf000.tile3.nc \
+                   dynf000.tile4.nc \
+                   dynf000.tile5.nc \
+                   dynf000.tile6.nc \
+                   dynf024.tile1.nc \
+                   dynf024.tile2.nc \
+                   dynf024.tile3.nc \
+                   dynf024.tile4.nc \
+                   dynf024.tile5.nc \
+                   dynf024.tile6.nc \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc"
+
+export_fv3
+
+export DT_ATMOS="600"
+export IMP_PHYSICS=8
+export DNATS=0
+export DO_SAT_ADJ=.F.
+export LRADAR=.T.
+export LTAEROSOL=.T.
+
+export FV3_RUN=ccpp_gsd_run.IN
+export CCPP_SUITE=FV3_GSD_noah
+export CCPP_LIB_DIR=ccpp/lib
+export INPUT_NML=ccpp_gsd.nml.IN
+
+export HYBEDMF=.F.
+export DO_MYNNEDMF=.T.
+export IMFSHALCNV=3
+export IMFDEEPCNV=3
+export LSM=1
+export LSOIL_LSM=4
+
+export LNDP_TYPE=2
+export N_VAR_LNDP=3
+
+#export WLCLK=30


### PR DESCRIPTION
## Description

This PR contains the following changes:
- update submodule pointers for stochastic_physics and fv3atm for the PRs listed belowe
- add regression tests `fv3_ccpp_gsd_lndp` and `fv3_ccpp_gsd_noah_lndp`

## Testing

### Final regression testing 01/08/2021

**Regression testing on hera.intel against existing baseline (using `rt.conf`)** passes for all tests except the following:
```
fv3_ccpp_lndp 015 failed in check_result
fv3_ccpp_hrrr 042 failed in check_result
fv3_ccpp_rap 041 failed in check_result
fv3_ccpp_rrfs_v1beta 045 failed in check_result
fv3_ccpp_gsd 040 failed in check_result
fv3_ccpp_rrfs_v1beta_debug 064 failed in check_result
fv3_ccpp_gsd_debug 060 failed in check_result
fv3_ccpp_gsd_diag3d_debug 061 failed in check_result
```
All of these tests run to completion, and the b4b mismatches are expected:
    - The b4b mismatch for `fv3_ccpp_lndp` is because of the change from `min_bound = minsmc (=0.02)` to `min_bound = smcmin(soiltyp)` for Noah LSM in `stochastic_physics/lndp_apply_perts.F90`. Reverting this particular change gives b4b identical results with the existing regression test.
    - The b4b mismatches for the remaining tests are because gsl/develop has marched ahead wrt RAP/HRRR physics.

[rt_hera_intel.log](https://github.com/NOAA-GSL/ufs-weather-model/files/5788688/rt_hera_intel.log)
[rt_hera_intel_fail_test.log](https://github.com/NOAA-GSL/ufs-weather-model/files/5788689/rt_hera_intel_fail_test.log)

**Regression testing on hera.gnu against existing baseline (using `rt_gnu.conf`)** passes for all tests except the following:
```
fv3_ccpp_rrfs_v1beta 010 failed in check_result
fv3_ccpp_gsd 007 failed in check_result
```
Both tests run to completion, and the b4b mismatches are expected because gsl/develop has marched ahead wrt RAP/HRRR physics.

[rt_hera_gnu.log](https://github.com/NOAA-GSL/ufs-weather-model/files/5788685/rt_hera_gnu.log)
[rt_hera_gnu_fail_test.log](https://github.com/NOAA-GSL/ufs-weather-model/files/5788686/rt_hera_gnu_fail_test.log)

**Testing on hera.intel using `rt_ccpp_dev.conf`:** first create new baseline (including the two new regression tests), then verify against it: all tests pass.

[rt_ccpp_dev_create.log](https://github.com/NOAA-GSL/ufs-weather-model/files/5788797/rt_ccpp_dev_create.log)
[rt_ccpp_dev_verify.log](https://github.com/NOAA-GSL/ufs-weather-model/files/5788798/rt_ccpp_dev_verify.log)

## Dependencies

https://github.com/NOAA-GSL/stochastic_physics/pull/1
https://github.com/NOAA-GSL/ccpp-physics/pull/71
https://github.com/NOAA-GSL/fv3atm/pull/68 (contains https://github.com/NOAA-GSL/fv3atm/pull/65)
https://github.com/NOAA-GSL/ufs-weather-model/pull/57