### PR TITLE
 Add namelist options to adjust the magnitude of emissions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
 	url = https://github.com/SamuelTrahanNOAA/fv3atm
-	branch = feature/perturb-everything
+	branch = feature/pert-scale
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/tests/chem.conf
+++ b/tests/chem.conf
@@ -1,4 +1,3 @@
 COMPILE | CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_2017_gfdlmp_gsd_chem                                      | standard    |                | fv3         |
 RUN     | fv3_ccpp_gfdlmp_gsd_chem                                                                                                       | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_gfdlmp_gsd_chem_sppt                                                                                                  | standard    | hera.intel     | fv3         |
-RUN     | fv3_ccpp_gfdlmp_gsd_chem_ca                                                                                                    | standard    | hera.intel     | fv3         |

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -75,7 +75,6 @@ COMPILE | CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_2
 RUN     | fv3_ccpp_gfdlmp                                                                                                                | standard    |                | fv3         |
 RUN     | fv3_ccpp_gfdlmp_gsd_chem                                                                                                       | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_gfdlmp_gsd_chem_sppt                                                                                                  | standard    | hera.intel     | fv3         |
-RUN     | fv3_ccpp_gfdlmp_gsd_chem_ca                                                                                                    | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_gfdlmprad_gwd                                                                                                         | standard    |                | fv3         |
 RUN     | fv3_ccpp_gfdlmprad_noahmp                                                                                                      | standard    |                | fv3         |
 RUN     | fv3_ccpp_gfdlmp_hwrfsas                                                                                                        | standard    | wcoss_cray     | fv3         |


### PR DESCRIPTION
This now adjusts the magnitude of perturbations:

```
  &gfs_physics_nml
        ...
        pert_scale_anthro = 0.9
        pert_scale_dust = 1.2
        pert_scale_plume = 1.3
        pert_scale_seas = 0.7
```
