### PR TITLE
gsd-chem stochastic emissions: scale factor, remove CA support, remove emis_multiplier

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
-	url = https://github.com/SamuelTrahanNOAA/fv3atm
-	branch = feature/pert-scale
+	url = https://github.com/NOAA-GSL/fv3atm
+	branch = gsd/develop-chem
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
 	path = FV3
 	url = https://github.com/SamuelTrahanNOAA/fv3atm
-	branch = feature/perturb-everything
+	branch = feature/pert-scale
 [submodule "NEMS"]
 	path = NEMS
 	url = https://github.com/NOAA-EMC/NEMS

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Wed Jan 13 22:27:06 UTC 2021
+Wed Jan 13 23:57:48 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch2/BMC/wrfruc/Samuel.Trahan/perturb-smoke/RT/NEMSfv3gfs/develop-20200929/INTEL//fv3_gfdlmp_gsd_chem_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_273668/fv3_ccpp_gfdlmp_gsd_chem_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_52240/fv3_ccpp_gfdlmp_gsd_chem_prod
 Checking test 001 fv3_ccpp_gfdlmp_gsd_chem results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -51,7 +51,7 @@ Test 001 fv3_ccpp_gfdlmp_gsd_chem PASS
 
 
 baseline dir = /scratch2/BMC/wrfruc/Samuel.Trahan/perturb-smoke/RT/NEMSfv3gfs/develop-20200929/INTEL//fv3_gfdlmp_gsd_chem_sppt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_273668/fv3_ccpp_gfdlmp_gsd_chem_sppt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_52240/fv3_ccpp_gfdlmp_gsd_chem_sppt_prod
 Checking test 002 fv3_ccpp_gfdlmp_gsd_chem_sppt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -99,5 +99,5 @@ Test 002 fv3_ccpp_gfdlmp_gsd_chem_sppt PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Jan 13 22:38:12 UTC 2021
-Elapsed time: 00h:11m:08s. Have a nice day!
+Thu Jan 14 00:08:53 UTC 2021
+Elapsed time: 00h:11m:07s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,9 +1,9 @@
-Mon Dec 21 21:19:48 UTC 2020
+Wed Jan 13 22:27:06 UTC 2021
 Start Regression test
 
 
 baseline dir = /scratch2/BMC/wrfruc/Samuel.Trahan/perturb-smoke/RT/NEMSfv3gfs/develop-20200929/INTEL//fv3_gfdlmp_gsd_chem_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_206865/fv3_ccpp_gfdlmp_gsd_chem_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_273668/fv3_ccpp_gfdlmp_gsd_chem_prod
 Checking test 001 fv3_ccpp_gfdlmp_gsd_chem results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -51,7 +51,7 @@ Test 001 fv3_ccpp_gfdlmp_gsd_chem PASS
 
 
 baseline dir = /scratch2/BMC/wrfruc/Samuel.Trahan/perturb-smoke/RT/NEMSfv3gfs/develop-20200929/INTEL//fv3_gfdlmp_gsd_chem_sppt_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_206865/fv3_ccpp_gfdlmp_gsd_chem_sppt_prod
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_273668/fv3_ccpp_gfdlmp_gsd_chem_sppt_prod
 Checking test 002 fv3_ccpp_gfdlmp_gsd_chem_sppt results ....
  Comparing atmos_4xdaily.tile1.nc .........OK
  Comparing atmos_4xdaily.tile2.nc .........OK
@@ -98,54 +98,6 @@ Checking test 002 fv3_ccpp_gfdlmp_gsd_chem_sppt results ....
 Test 002 fv3_ccpp_gfdlmp_gsd_chem_sppt PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/Samuel.Trahan/perturb-smoke/RT/NEMSfv3gfs/develop-20200929/INTEL//fv3_gfdlmp_gsd_chem_ca_ccpp
-working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_206865/fv3_ccpp_gfdlmp_gsd_chem_ca_prod
-Checking test 003 fv3_ccpp_gfdlmp_gsd_chem_ca results ....
- Comparing atmos_4xdaily.tile1.nc .........OK
- Comparing atmos_4xdaily.tile2.nc .........OK
- Comparing atmos_4xdaily.tile3.nc .........OK
- Comparing atmos_4xdaily.tile4.nc .........OK
- Comparing atmos_4xdaily.tile5.nc .........OK
- Comparing atmos_4xdaily.tile6.nc .........OK
- Comparing phyf000.nemsio .........OK
- Comparing phyf024.nemsio .........OK
- Comparing dynf000.nemsio .........OK
- Comparing dynf024.nemsio .........OK
- Comparing RESTART/coupler.res .........OK
- Comparing RESTART/fv_core.res.nc .........OK
- Comparing RESTART/fv_core.res.tile1.nc .........OK
- Comparing RESTART/fv_core.res.tile2.nc .........OK
- Comparing RESTART/fv_core.res.tile3.nc .........OK
- Comparing RESTART/fv_core.res.tile4.nc .........OK
- Comparing RESTART/fv_core.res.tile5.nc .........OK
- Comparing RESTART/fv_core.res.tile6.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
- Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
- Comparing RESTART/fv_tracer.res.tile1.nc .........OK
- Comparing RESTART/fv_tracer.res.tile2.nc .........OK
- Comparing RESTART/fv_tracer.res.tile3.nc .........OK
- Comparing RESTART/fv_tracer.res.tile4.nc .........OK
- Comparing RESTART/fv_tracer.res.tile5.nc .........OK
- Comparing RESTART/fv_tracer.res.tile6.nc .........OK
- Comparing RESTART/sfc_data.tile1.nc .........OK
- Comparing RESTART/sfc_data.tile2.nc .........OK
- Comparing RESTART/sfc_data.tile3.nc .........OK
- Comparing RESTART/sfc_data.tile4.nc .........OK
- Comparing RESTART/sfc_data.tile5.nc .........OK
- Comparing RESTART/sfc_data.tile6.nc .........OK
- Comparing RESTART/phy_data.tile1.nc .........OK
- Comparing RESTART/phy_data.tile2.nc .........OK
- Comparing RESTART/phy_data.tile3.nc .........OK
- Comparing RESTART/phy_data.tile4.nc .........OK
- Comparing RESTART/phy_data.tile5.nc .........OK
- Comparing RESTART/phy_data.tile6.nc .........OK
-Test 003 fv3_ccpp_gfdlmp_gsd_chem_ca PASS
-
-
 REGRESSION TEST WAS SUCCESSFUL
-Mon Dec 21 21:40:05 UTC 2020
-Elapsed time: 00h:20m:19s. Have a nice day!
+Wed Jan 13 22:38:12 UTC 2021
+Elapsed time: 00h:11m:08s. Have a nice day!

--- a/tests/chem.conf
+++ b/tests/chem.conf
@@ -1,4 +1,3 @@
 COMPILE | CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_2017_gfdlmp_gsd_chem                                      | standard    |                | fv3         |
 RUN     | fv3_ccpp_gfdlmp_gsd_chem                                                                                                       | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_gfdlmp_gsd_chem_sppt                                                                                                  | standard    | hera.intel     | fv3         |
-RUN     | fv3_ccpp_gfdlmp_gsd_chem_ca                                                                                                    | standard    | hera.intel     | fv3         |

--- a/tests/rt.conf
+++ b/tests/rt.conf
@@ -75,7 +75,6 @@ COMPILE | CCPP=Y SUITES=FV3_GFS_2017_gfdlmp,FV3_GFS_2017_gfdlmp_noahmp,FV3_GFS_2
 RUN     | fv3_ccpp_gfdlmp                                                                                                                | standard    |                | fv3         |
 RUN     | fv3_ccpp_gfdlmp_gsd_chem                                                                                                       | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_gfdlmp_gsd_chem_sppt                                                                                                  | standard    | hera.intel     | fv3         |
-RUN     | fv3_ccpp_gfdlmp_gsd_chem_ca                                                                                                    | standard    | hera.intel     | fv3         |
 RUN     | fv3_ccpp_gfdlmprad_gwd                                                                                                         | standard    |                | fv3         |
 RUN     | fv3_ccpp_gfdlmprad_noahmp                                                                                                      | standard    |                | fv3         |
 RUN     | fv3_ccpp_gfdlmp_hwrfsas                                                                                                        | standard    | wcoss_cray     | fv3         |


### PR DESCRIPTION
These changes introduce a scaling factor for emissions when stochastic perturbations are enabled. Also, they eliminate support for ca_global_chem. Removing that let us also remove the `emis_multiplier` array and code that initialized it.

The fv3atm PR is https://github.com/NOAA-GSL/fv3atm/pull/71
The ccpp/physics PR is https://github.com/NOAA-GSL/ccpp-physics/pull/73