### PR TITLE
RRFS_cloud: Build 32-bit dynamics by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,8 @@ project(ufs
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/CMakeModules/Modules)
 
-set(32BIT           OFF CACHE BOOL "Enable 32BIT (single precision arithmetic in dycore)")
+set(32BIT           ON  CACHE BOOL "Enable 32BIT (single precision arithmetic in dycore)")
+set(DYN32           ON  CACHE BOOL "Enable 32BIT (single precision arithmetic in dycore)")
 set(AVX2            ON  CACHE BOOL "Enable AVX2 instruction set")
 set(SIMDMULTIARCH   OFF CACHE BOOL "Enable multi-target SIMD instruction sets")
 set(CCPP            ON  CACHE BOOL "Enable CCPP")


### PR DESCRIPTION
## Description
Sets the default to 32 bit dynamics build for the RRFS cloud project.

### Issue(s) addressed

Addressing [Issue #358](https://github.com/ufs-community/ufs-weather-model/issues/358) in ufs-community for this project only.

## Testing

Mods tested by several in the group on AWS and on Hera.
Jim Abeles
Raj Panda
Christina Holt

## Dependencies

N/A
