### PR TITLE
Update thompson mp 20210213 (#567) for gsl/develop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-GSL/fv3atm
-  #branch = gsl/develop
-  url = https://github.com/climbfuji/fv3atm
-  branch = update_thompsonMP_20210213_merged_into_gsl_develop
+  url = https://github.com/NOAA-GSL/fv3atm
+  branch = gsl/develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-GSL/fv3atm
-  branch = gsl/develop
+  #url = https://github.com/NOAA-GSL/fv3atm
+  #branch = gsl/develop
+  url = https://github.com/climbfuji/fv3atm
+  branch = update_thompsonMP_20210213_merged_into_gsl_develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/tests/fv3_conf/ccpp_c96_HAFS_v0_hwrf_run.IN
+++ b/tests/fv3_conf/ccpp_c96_HAFS_v0_hwrf_run.IN
@@ -83,3 +83,10 @@ if [ $IMP_PHYSICS = 8 ]; then
 elif [ $IMP_PHYSICS = 15 ]; then
   cp @[INPUTDATA_ROOT]/FV3_input_data/DETAMPNEW_DATA* .
 fi
+
+# temporary: new Thompson tables
+if [[ $MACHINE_ID = cheyenne.* ]]; then
+  cp /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/tmp_input_data_thompson_update_20210304/* .
+else
+  cp /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/tmp_input_data_thompson_update_20210304/* .
+fi

--- a/tests/fv3_conf/ccpp_esg_HAFS_v0_hwrf_run.IN
+++ b/tests/fv3_conf/ccpp_esg_HAFS_v0_hwrf_run.IN
@@ -45,3 +45,10 @@ else
   echo "ERROR, no field table configured for IMP_PHYSICS=${IMP_PHYSICS}"
   exit 1
 fi
+
+# temporary: new Thompson tables
+if [[ $MACHINE_ID = cheyenne.* ]]; then
+  cp /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/tmp_input_data_thompson_update_20210304/* .
+else
+  cp /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/tmp_input_data_thompson_update_20210304/* .
+fi

--- a/tests/fv3_conf/ccpp_gf_thompson_run.IN
+++ b/tests/fv3_conf/ccpp_gf_thompson_run.IN
@@ -21,3 +21,10 @@ cp    @[INPUTDATA_ROOT]/FV3_input_data_gsd/qr_acr_qs.dat .
 cp    @[INPUTDATA_ROOT]/FV3_input_data_gsd/qr_acr_qg.dat .
 cp    @[INPUTDATA_ROOT]/FV3_input_data_gsd/freezeH2O.dat .
 cp    @[INPUTDATA_ROOT]/FV3_input_data_gsd/CCN_ACTIVATE.BIN .
+
+# temporary: new Thompson tables
+if [[ $MACHINE_ID = cheyenne.* ]]; then
+  cp /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/tmp_input_data_thompson_update_20210304/* .
+else
+  cp /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/tmp_input_data_thompson_update_20210304/* .
+fi

--- a/tests/fv3_conf/ccpp_gsd_run.IN
+++ b/tests/fv3_conf/ccpp_gsd_run.IN
@@ -68,3 +68,10 @@ fi
 if [ $GWD_OPT = 3 ] || [ $GWD_OPT = 33 ] || [ $GWD_OPT = 2 ] || [ $GWD_OPT = 22 ]; then
   cp @[INPUTDATA_ROOT]/FV3_input_data_gsd/drag_suite/* INPUT/
 fi
+
+# temporary: new Thompson tables
+if [[ $MACHINE_ID = cheyenne.* ]]; then
+  cp /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/tmp_input_data_thompson_update_20210304/* .
+else
+  cp /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/tmp_input_data_thompson_update_20210304/* .
+fi

--- a/tests/fv3_conf/ccpp_gsd_sar_run.IN
+++ b/tests/fv3_conf/ccpp_gsd_sar_run.IN
@@ -23,3 +23,10 @@ cp @[INPUTDATA_ROOT]/FV3_input_data_gsd/qr_acr_qs.dat .
 cp @[INPUTDATA_ROOT]/FV3_input_data_gsd/qr_acr_qg.dat .
 cp @[INPUTDATA_ROOT]/FV3_input_data_gsd/freezeH2O.dat .
 cp @[INPUTDATA_ROOT]/FV3_input_data_gsd/CCN_ACTIVATE.BIN .
+
+# temporary: new Thompson tables
+if [[ $MACHINE_ID = cheyenne.* ]]; then
+  cp /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/tmp_input_data_thompson_update_20210304/* .
+else
+  cp /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/tmp_input_data_thompson_update_20210304/* .
+fi

--- a/tests/fv3_conf/ccpp_regional_run.IN
+++ b/tests/fv3_conf/ccpp_regional_run.IN
@@ -28,3 +28,10 @@ fi
 if [ $H2O_PHYS = .T. ]; then
   cp  @[INPUTDATA_ROOT]/FV3_input_data/global_h2o_pltc.f77 ./global_h2oprdlos.f77
 fi
+
+# temporary: new Thompson tables
+if [[ $MACHINE_ID = cheyenne.* ]]; then
+  cp /glade/p/ral/jntp/GMTB/ufs-weather-model/RT/NEMSfv3gfs/tmp_input_data_thompson_update_20210304/* .
+else
+  cp /scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/tmp_input_data_thompson_update_20210304/* .
+fi


### PR DESCRIPTION
## Description

This PR updates the submodule pointer for fv3atm / ccpp-physics for the changes described in NOAA-GSL/ccpp-physics#80.

## Testing

Regression testing against existing baselines on hera.intel: tests pass except the following (as expected, due to changes in Thompson MP and RUC LSM) - all these tests run to completion:
```
fv3_ccpp_hrrr
fv3_ccpp_rap
fv3_ccpp_thompson
fv3_ccpp_thompson_no_aero
fv3_ccpp_gsd
fv3_ccpp_regional_quilt_netcdf_parallel
fv3_ccpp_regional_quilt
fv3_ccpp_regional_control
fv3_ccpp_gsd_debug
fv3_ccpp_rrfs_v1beta_debug
fv3_ccpp_regional_control_debug
fv3_ccpp_gsd_diag3d_debug
fv3_ccpp_thompson_debug
fv3_ccpp_thompson_no_aero_debug
fv3_ccpp_rrfs_v1beta
```
[rt_hera_intel_against_existing_baseline.log](https://github.com/NOAA-GSL/ufs-weather-model/files/6148606/rt_hera_intel_against_existing_baseline.log)
[rt_hera_intel_against_existing_baseline_fail_test.log](https://github.com/NOAA-GSL/ufs-weather-model/files/6148607/rt_hera_intel_against_existing_baseline_fail_test.log)

Regression testing against existing baselines on hera.gnu: tests pass except the following (as expected, due to changes in Thompson MP and RUC LSM) - all these tests run to completion:
```
fv3_ccpp_regional_control_debug
fv3_ccpp_rrfs_v1beta_debug
fv3_ccpp_gsd_debug
fv3_ccpp_thompson_debug
fv3_ccpp_thompson_no_aero_debug
fv3_ccpp_thompson_no_aero
fv3_ccpp_thompson
fv3_ccpp_rrfs_v1beta
fv3_ccpp_gsd
```
[rt_hera_gnu_against_existing_baseline.log](https://github.com/NOAA-GSL/ufs-weather-model/files/6148618/rt_hera_gnu_against_existing_baseline.log)
[rt_hera_gnu_against_existing_baseline_fail_test.log](https://github.com/NOAA-GSL/ufs-weather-model/files/6148620/rt_hera_gnu_against_existing_baseline_fail_test.log)

Regression testing on hera.intel and hera.gnu using `rt_ccpp_dev.conf`: first create baseline, then verify against it: all tests pass

[rt_ccpp_dev_hera_gnu_create.log](https://github.com/NOAA-GSL/ufs-weather-model/files/6148626/rt_ccpp_dev_hera_gnu_create.log)
[rt_ccpp_dev_hera_gnu_verify.log](https://github.com/NOAA-GSL/ufs-weather-model/files/6148627/rt_ccpp_dev_hera_gnu_verify.log)
[rt_ccpp_dev_hera_intel_create.log](https://github.com/NOAA-GSL/ufs-weather-model/files/6148628/rt_ccpp_dev_hera_intel_create.log)
[rt_ccpp_dev_hera_intel_verify.log](https://github.com/NOAA-GSL/ufs-weather-model/files/6148629/rt_ccpp_dev_hera_intel_verify.log)


## Dependencies

https://github.com/NOAA-GSL/ccpp-physics/pull/80 (contains https://github.com/NCAR/ccpp-physics/pull/567)
https://github.com/NOAA-GSL/fv3atm/pull/75
https://github.com/NOAA-GSL/ufs-weather-model/pull/65