### PR TITLE
Fix incorrect units in dtend metadata

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/SamuelTrahanNOAA/fv3atm
-  branch = bugfix/dtend-units
+  url = https://github.com/NOAA-GSL/fv3atm
+  branch = gsl/develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-GSL/fv3atm
-  branch = gsl/develop
+  url = https://github.com/SamuelTrahanNOAA/fv3atm
+  branch = bugfix/dtend-units
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS


### PR DESCRIPTION
Several units in dtend output variables had the wrong units (kg/(kg*s)). This is now corrected.

Corresponding fv3atm PR:

* https://github.com/NOAA-GSL/fv3atm/pull/82

This error was discovered during review of the documentation PR:

* https://github.com/NCAR/ccpp-doc/pull/38

Which was reviewed by @ligiabernardet

----------

**Note:** This PR must not be merged until the submodule for FV3 is pointed back to NOAA-GSL. It points to SamuelTrahanNOAA so the branch can be recursively cloned and tested.