### PR TITLE
Move all GSD chemistry process modules from ccpp-physics to GOCART

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-GSL/fv3atm
-  #branch = gsl/develop-chem
-  url = https://github.com/climbfuji/fv3atm
-  branch = move-all-gsd-chem-process-modules
+  url = https://github.com/NOAA-GSL/fv3atm
+  branch = gsl/develop-chem
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS
@@ -22,10 +20,8 @@
   branch = gsl/develop
 [submodule "gocart"]
   path = gocart-interface/gocart
-  #url = https://github.com/NOAA-GSL/GOCART
-  #branch = gsl/develop-chem
-  url = https://github.com/climbfuji/GOCART
-  branch = move-all-gsd-chem-process-modules
+  url = https://github.com/NOAA-GSL/GOCART
+  branch = gsl/develop-chem
 [submodule "CMakeModules"]
   path = CMakeModules
   url = https://github.com/NOAA-EMC/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-GSL/fv3atm
-  branch = gsl/develop-chem
+  #url = https://github.com/NOAA-GSL/fv3atm
+  #branch = gsl/develop-chem
+  url = https://github.com/climbfuji/fv3atm
+  branch = move-all-gsd-chem-process-modules
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS
@@ -20,8 +22,10 @@
   branch = gsl/develop
 [submodule "gocart"]
   path = gocart-interface/gocart
-  url = https://github.com/NOAA-GSL/GOCART
-  branch = gsl/develop-chem
+  #url = https://github.com/NOAA-GSL/GOCART
+  #branch = gsl/develop-chem
+  url = https://github.com/climbfuji/GOCART
+  branch = move-all-gsd-chem-process-modules
 [submodule "CMakeModules"]
   path = CMakeModules
   url = https://github.com/NOAA-EMC/CMakeModules

--- a/gocart-interface/CMakeLists.txt
+++ b/gocart-interface/CMakeLists.txt
@@ -38,6 +38,54 @@ list(APPEND _gocart_srcs gocart/Process_Library/aero_soa_vbs_data_mod.F90
                          gocart/Process_Library/GOCART2G_Process.F90)
 add_library(gocart ${_gocart_srcs})
 
+# Force 64bit for files that are just too hard to change
+if(32BIT)
+  if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
+    set (CMAKE_Fortran_FLAGS_64bit "${CMAKE_Fortran_FLAGS}")
+    if(REPRO)
+      string (REPLACE "-i4 -real-size 32" "-i4 -real-size 64" CMAKE_Fortran_FLAGS_64bit "${CMAKE_Fortran_FLAGS_64bit}")
+    else()
+      string (REPLACE "-i4 -real-size 32" "-i4 -real-size 64 -no-prec-div -no-prec-sqrt" CMAKE_Fortran_FLAGS_64bit "${CMAKE_Fortran_FLAGS_64bit}")
+    endif()
+  elseif(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
+    set(CMAKE_Fortran_FLAGS_64bit "${CMAKE_Fortran_FLAGS_64bit} -fdefault-real-8")
+  endif()
+  SET_SOURCE_FILES_PROPERTIES(gocart/Process_Library/aero_soa_vbs_data_mod.F90
+                         gocart/Process_Library/dep_dry_gocart_mod.F90
+                         gocart/Process_Library/dep_dry_mod.F90
+                         gocart/Process_Library/dep_simple_mod.F90
+                         gocart/Process_Library/dep_vertmx_mod.F90
+                         gocart/Process_Library/dep_wet_ls_mod.F90
+                         gocart/Process_Library/dust_afwa_mod.F90
+                         gocart/Process_Library/dust_data_mod.F90
+                         gocart/Process_Library/dust_fengsha_mod.F90
+                         gocart/Process_Library/dust_gocart_mod.F90
+                         gocart/Process_Library/gocart_aerosols_mod.F90
+                         gocart/Process_Library/gocart_chem_mod.F90
+                         gocart/Process_Library/gocart_diag_mod.F90
+                         gocart/Process_Library/gocart_dmsemis_mod.F90
+                         gocart/Process_Library/gocart_settling_mod.F90
+                         gocart/Process_Library/gsd_chem_config.F90
+                         gocart/Process_Library/gsd_chem_constants.F90
+                         gocart/Process_Library/opt_aer_mod.F90
+                         gocart/Process_Library/opt_aer_out_mod.F90
+                         gocart/Process_Library/opt_aer_ra_mod.F90
+                         gocart/Process_Library/opt_averaging_mod.F90
+                         gocart/Process_Library/opt_data_mod.F90
+                         gocart/Process_Library/opt_driver_mod.F90
+                         gocart/Process_Library/opt_gocart_mod.F90
+                         gocart/Process_Library/opt_mod.F90
+                         gocart/Process_Library/plume_data_mod.F90
+                         gocart/Process_Library/plume_rise_mod.F90
+                         gocart/Process_Library/plume_scalar_mod.F90
+                         gocart/Process_Library/plume_zero_mod.F90
+                         gocart/Process_Library/seas_data_mod.F90
+                         gocart/Process_Library/seas_mod.F90
+                         gocart/Process_Library/seas_ngac_mod.F90
+                         gocart/Process_Library/vash_settling_mod.F90
+                         PROPERTIES COMPILE_FLAGS "${CMAKE_Fortran_FLAGS_64bit}")
+endif()
+
 target_compile_definitions(gocart PRIVATE "HAS_NETCDF3")
 set_target_properties(gocart PROPERTIES Fortran_MODULE_DIRECTORY
                                         ${CMAKE_CURRENT_BINARY_DIR}/mod)

--- a/gocart-interface/CMakeLists.txt
+++ b/gocart-interface/CMakeLists.txt
@@ -1,12 +1,39 @@
 # this will look for MAPL and all the other stuff we don't needd
 #add_subdirectory(gocart)
 
-list(APPEND _gocart_srcs gocart/Process_Library/gsd_chem_constants.F90
+list(APPEND _gocart_srcs gocart/Process_Library/aero_soa_vbs_data_mod.F90
+                         gocart/Process_Library/dep_dry_gocart_mod.F90
+                         gocart/Process_Library/dep_dry_mod.F90
+                         gocart/Process_Library/dep_simple_mod.F90
+                         gocart/Process_Library/dep_vertmx_mod.F90
+                         gocart/Process_Library/dep_wet_ls_mod.F90
+                         gocart/Process_Library/dust_afwa_mod.F90
+                         gocart/Process_Library/dust_data_mod.F90
+                         gocart/Process_Library/dust_fengsha_mod.F90
+                         gocart/Process_Library/dust_gocart_mod.F90
+                         gocart/Process_Library/gocart_aerosols_mod.F90
+                         gocart/Process_Library/gocart_chem_mod.F90
+                         gocart/Process_Library/gocart_diag_mod.F90
+                         gocart/Process_Library/gocart_dmsemis_mod.F90
+                         gocart/Process_Library/gocart_settling_mod.F90
                          gocart/Process_Library/gsd_chem_config.F90
+                         gocart/Process_Library/gsd_chem_constants.F90
+                         gocart/Process_Library/opt_aer_mod.F90
+                         gocart/Process_Library/opt_aer_out_mod.F90
+                         gocart/Process_Library/opt_aer_ra_mod.F90
+                         gocart/Process_Library/opt_averaging_mod.F90
+                         gocart/Process_Library/opt_data_mod.F90
+                         gocart/Process_Library/opt_driver_mod.F90
+                         gocart/Process_Library/opt_gocart_mod.F90
+                         gocart/Process_Library/opt_mod.F90
                          gocart/Process_Library/plume_data_mod.F90
                          gocart/Process_Library/plume_rise_mod.F90
                          gocart/Process_Library/plume_scalar_mod.F90
                          gocart/Process_Library/plume_zero_mod.F90
+                         gocart/Process_Library/seas_data_mod.F90
+                         gocart/Process_Library/seas_mod.F90
+                         gocart/Process_Library/seas_ngac_mod.F90
+                         gocart/Process_Library/vash_settling_mod.F90
                          gocart/Process_Library/Chem_MieTableMod2G.F90
                          gocart/Process_Library/GOCART2G_Process.F90)
 add_library(gocart ${_gocart_srcs})


### PR DESCRIPTION
## Description

This PR:
- Updates the submodule pointer for ccpp-physics for the changes in the associated PRs listed below.
- Force 64bit for several GSD chemistry modules in the GOCART repository that are just very hard to change.

Note 1. GOCART is always compiled in double precision, similar to ccpp-physics, independent of whether the dycore and fv3atm are using double precision or single precision.

**Note 2.** Updating the GSD chemistry routines to a modern Fortran standard and combining them into a smaller number of manageable and well-structured files is **out of scope** for this PR and not my business. My task is only to get all these routines across from ccpp-physics to gocart and enable calling them from ccpp-physics.

## Testing

Regression testing on Hera with Intel and GNU: the new code is compared against the baselines created with the current head of the code using `rt_ccpp_dev.conf`.

With GNU, all regression tests pass (including `fv3_gfdlmp_gsd_chem` and `fv3_gfdlmp_gsd_chem_sppt` in PROD and DEBUG mode; note that GNU cannot run `fv3_gfdlmp_gsd_chem_ca`/`fv3_gfdlmp_gsd_chem_ca_debug` due to bugs in the cellular automata code, i.e. unrelated to the work here).

[rt_hera_gnu_verify_against_existing.log](https://github.com/NOAA-GSL/ufs-weather-model/files/6380752/rt_hera_gnu_verify_against_existing.log)

With Intel, all regression tests pass in DEBUG mode (including the three chemistry tests), and all _except_ the three chemistry tests pass in PROD mode (but they run to completion). For the latter three, there are round-off differences for the chemical species in the output files, example:
```
Dom.Heinzeller@hfe05:/scratch1/BMC/gmtb/Dom.Heinzeller/ufs-weather-model/ufs-weather-model-gsl-develop-chem-move-all-gsd-chem-process-modules/intel/tests [intel|gsd-hpcs]> cat log_hera.intel/rt_023_fv3_gfdlmp_gsd_chem_ca_repro.log

baseline dir = /scratch1/NCEPDEV/stmp4/Dom.Heinzeller/FV3_RT/REGRESSION_TEST_INTEL/fv3_gfdlmp_gsd_chem_ca_repro
working dir  = /scratch1/NCEPDEV/stmp2/Dom.Heinzeller/FV3_RT/rt_40623/fv3_gfdlmp_gsd_chem_ca_repro
Checking test 023 fv3_gfdlmp_gsd_chem_ca results ....
 Comparing atmos_4xdaily.tile1.nc .........OK
 Comparing atmos_4xdaily.tile2.nc .........OK
 Comparing atmos_4xdaily.tile3.nc .........OK
 Comparing atmos_4xdaily.tile4.nc .........OK
 Comparing atmos_4xdaily.tile5.nc .........OK
 Comparing atmos_4xdaily.tile6.nc .........OK
 Comparing phyf000.nemsio .........OK
 Comparing phyf024.nemsio .........OK
 Comparing dynf000.nemsio .........OK
 Comparing dynf024.nemsio .........NOT OK
 Comparing RESTART/coupler.res .........OK
 Comparing RESTART/fv_core.res.nc .........OK
 Comparing RESTART/fv_core.res.tile1.nc .........OK
 Comparing RESTART/fv_core.res.tile2.nc .........OK
 Comparing RESTART/fv_core.res.tile3.nc .........OK
 Comparing RESTART/fv_core.res.tile4.nc .........OK
 Comparing RESTART/fv_core.res.tile5.nc .........OK
 Comparing RESTART/fv_core.res.tile6.nc .........OK
 Comparing RESTART/fv_srf_wnd.res.tile1.nc .........OK
 Comparing RESTART/fv_srf_wnd.res.tile2.nc .........OK
 Comparing RESTART/fv_srf_wnd.res.tile3.nc .........OK
 Comparing RESTART/fv_srf_wnd.res.tile4.nc .........OK
 Comparing RESTART/fv_srf_wnd.res.tile5.nc .........OK
 Comparing RESTART/fv_srf_wnd.res.tile6.nc .........OK
 Comparing RESTART/fv_tracer.res.tile1.nc ............ALT CHECK......NOT OK
 Comparing RESTART/fv_tracer.res.tile2.nc ............ALT CHECK......NOT OK
 Comparing RESTART/fv_tracer.res.tile3.nc ............ALT CHECK......NOT OK
 Comparing RESTART/fv_tracer.res.tile4.nc ............ALT CHECK......NOT OK
 Comparing RESTART/fv_tracer.res.tile5.nc ............ALT CHECK......NOT OK
 Comparing RESTART/fv_tracer.res.tile6.nc ............ALT CHECK......NOT OK
 Comparing RESTART/sfc_data.tile1.nc .........OK
 Comparing RESTART/sfc_data.tile2.nc .........OK
 Comparing RESTART/sfc_data.tile3.nc .........OK
 Comparing RESTART/sfc_data.tile4.nc .........OK
 Comparing RESTART/sfc_data.tile5.nc .........OK
 Comparing RESTART/sfc_data.tile6.nc .........OK
 Comparing RESTART/phy_data.tile1.nc .........OK
 Comparing RESTART/phy_data.tile2.nc .........OK
 Comparing RESTART/phy_data.tile3.nc .........OK
 Comparing RESTART/phy_data.tile4.nc .........OK
 Comparing RESTART/phy_data.tile5.nc .........OK
 Comparing RESTART/phy_data.tile6.nc .........OK

  0: The total amount of wall time                        = 183.208985

Test 023 fv3_gfdlmp_gsd_chem_ca FAIL
```
Note that the restart files for surface data and physics data are b4b identical, i.e. the model dynamics are not affected.

Given that the chemistry tests pass against the existing baselines in DEBUG mode for both Intel and GNU, and in PROD mode for GNU, and do not affect the model dynamics/state, the differences are acceptable in my opinion.

[rt_hera_intel_verify_against_existing.log](https://github.com/NOAA-GSL/ufs-weather-model/files/6380780/rt_hera_intel_verify_against_existing.log)
[rt_hera_intel_verify_against_existing_fail_test.log](https://github.com/NOAA-GSL/ufs-weather-model/files/6380781/rt_hera_intel_verify_against_existing_fail_test.log)

### Additional tests

I also made sure that the ufs-weather-model code compiles when not specifying any suites (i.e. using all suites, schemes and their dependencies) in 32bit and 64bit. We can't do this with Intel, because the Intel compiler aborts with an internal error (the auto-generated caps are too complex to optimize; this is not a problem with this PR, it has been like this ever since the number of suites grew beyond 30 or so).

## Dependencies

https://github.com/NOAA-GSL/GOCART/pull/3
https://github.com/NOAA-GSL/ccpp-physics/pull/88
https://github.com/NOAA-GSL/fv3atm/pull/87
https://github.com/NOAA-GSL/ufs-weather-model/pull/75