### PR TITLE
Add missing cmake configure file for the aws.intel platform

### DIFF
--- a/cmake/configure_aws.intel.cmake
+++ b/cmake/configure_aws.intel.cmake
@@ -1,0 +1,2 @@
+set(INLINE_POST     ON CACHE BOOL "Enable inline post" FORCE)
+set(PARALLEL_NETCDF ON CACHE BOOL "Enable parallel NetCDF" FORCE)


### PR DESCRIPTION
# PR Checklist

- [x] Ths PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [ ] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [ ] If new or updated input data is required by this PR, it is clearly stated in the text of the PR.

## Description

The `CMAKE_Platform` defined in ` ufs-srweather-app/env/build_aws_intel.env` is set to: `aws.intel`.  This means that the ufs-weather-model looks for a file named `cmake/configure_aws.intel.cmake`.  That file did not exist and, therefore, the build of ufs-weather-model was not getting correct settings.  This PR fixes that problem.

### Issue(s) addressed

No linked issues.  See description above.

## Testing

Tested on Parallel Works AWS

- [x] AWS

## Dependencies

No dependencies
