### PR TITLE
Enable 32-bit mode for AWS runs

### DIFF
--- a/cmake/configure_aws.intel.cmake
+++ b/cmake/configure_aws.intel.cmake
@@ -1,2 +1,3 @@
+set(32BIT           ON CACHE BOOL "Enable 32BIT (single precision arithmetic in dycore)" FORCE)
 set(INLINE_POST     ON CACHE BOOL "Enable inline post" FORCE)
 set(PARALLEL_NETCDF ON CACHE BOOL "Enable parallel NetCDF" FORCE)


### PR DESCRIPTION
# PR Checklist

- [x] Ths PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [x] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [ ] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [ ] If new or updated input data is required by this PR, it is clearly stated in the text of the PR.

## Description

This PR turns 32BIT mode on in the build for AWS.

### Issue(s) addressed

No open issue is addressed, but major performance improvement on AWS.

## Testing

Tested on AWS Parallel Works

- [x] aws

## Dependencies

None
