### PR TITLE
Testing Flake model with HRRR and GSD_v0 suites

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-GSL/fv3atm
-  #branch = gsl/develop
-  url = https://github.com/tanyasmirnova/fv3atm
-  branch = gsl_dev_11aug21_lake
+  url = https://github.com/NOAA-GSL/fv3atm
+  branch = gsl/develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-GSL/fv3atm
-  branch = gsl/develop
+  #url = https://github.com/NOAA-GSL/fv3atm
+  #branch = gsl/develop
+  url = https://github.com/tanyasmirnova/fv3atm
+  branch = gsl_dev_11aug21_lake
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS


### PR DESCRIPTION
## Description

This PR updates the submodule pointer for fv3atm for the changes described in https://github.com/NOAA-GSL/fv3atm/pull/105 and https://github.com/NOAA-GSL/ccpp-physics/pull/103 (both contributed by @tanyasmirnova).

## Testing

Regression testing using `rt_ccpp_dev.conf` (first create temporary baseline, then verify against it):

- all tests pass on Hera/Intel
[rt_ccpp_dev_hera_intel_create_and_verify.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7024471/rt_ccpp_dev_hera_intel_create_and_verify.log)

- all tests pass on Hera/GNU
[rt_ccpp_dev_hera_gnu_create_and_verify.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7033186/rt_ccpp_dev_hera_gnu_create_and_verify.log)

Regression testing using `rt.conf` against official baseline on Hera/Intel: all tests run to completion, and only those that are expected to fail with b4b differences do not reproduce the existing baseline
[rt_hera_intel_verify_against_existing.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7033197/rt_hera_intel_verify_against_existing.log)
[rt_hera_intel_verify_against_existing_fail_test.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7033198/rt_hera_intel_verify_against_existing_fail_test.log)

Regression testing using `rt_gnu.conf` against official baseline on Hera/GNU: all tests run to completion, and only those that are expected to fail with b4b differences do not reproduce the existing baseline
[rt_hera_gnu_verify_against_existing.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7033330/rt_hera_gnu_verify_against_existing.log)
[rt_hera_gnu_verify_against_existing_fail_test.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7033332/rt_hera_gnu_verify_against_existing_fail_test.log)

## Dependencies

https://github.com/NOAA-GSL/fv3atm/pull/105
https://github.com/NOAA-GSL/ccpp-physics/pull/103
https://github.com/NOAA-GSL/ufs-weather-model/pull/99