### PR TITLE
Updates to MYNN-EDMF in CCPP physics

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,7 @@
 [submodule "FV3"]
   path = FV3
-  #url = https://github.com/NOAA-GSL/fv3atm
-  #branch = gsl/develop
-  url = https://github.com/climbfuji/fv3atm
-  branch = joe_mynn_updates_20211020
+  url = https://github.com/NOAA-GSL/fv3atm
+  branch = gsl/develop
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "FV3"]
   path = FV3
-  url = https://github.com/NOAA-GSL/fv3atm
-  branch = gsl/develop
+  #url = https://github.com/NOAA-GSL/fv3atm
+  #branch = gsl/develop
+  url = https://github.com/climbfuji/fv3atm
+  branch = joe_mynn_updates_20211020
 [submodule "NEMS"]
   path = NEMS
   url = https://github.com/NOAA-EMC/NEMS


### PR DESCRIPTION
## Description

This PR only updates the submodule pointers for fv3atm and ccpp-physics for the code changes described in https://github.com/NOAA-GSL/ccpp-physics/pull/110.

## Dependencies

https://github.com/NOAA-GSL/ccpp-physics/pull/110
https://github.com/NOAA-GSL/fv3atm/pull/112
https://github.com/NOAA-GSL/ufs-weather-model/pull/106

## Testing

Regression testing on Hera with Intel and GNU:

1. Using `rt_ccpp_dev.conf`, create new temporary baselines and verify against them. All tests pass, except `fv3_gsd_sar` and `fv3_gsd_sar_debug`. This is a known issue and requires an update to the FV3 dycore, which will be committed to the authoritative repositories today/tomorrow and then brought over to gsl/develop.

[rt_ccpp_dev_hera_intel_create.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7389546/rt_ccpp_dev_hera_intel_create.log)
[rt_ccpp_dev_hera_intel_verify.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7389550/rt_ccpp_dev_hera_intel_verify.log)
[rt_ccpp_dev_hera_gnu_create.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7389551/rt_ccpp_dev_hera_gnu_create.log)
[rt_ccpp_dev_hera_gnu_verify.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7389552/rt_ccpp_dev_hera_gnu_verify.log)

2. Testing against existing/official baselines using `rt.conf`/`rt_gnu.conf`: all tests pass, except those that are expected to fail due to b4b mismatches (because of changes in gsl/develop that are not yet in the authoritative repositories). All of these tests run to completion.

[rt_hera_intel_verify_against_existing.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7389561/rt_hera_intel_verify_against_existing.log)
[rt_hera_intel_verify_against_existing_fail_test.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7389562/rt_hera_intel_verify_against_existing_fail_test.log)
[rt_hera_gnu_verify_against_existing.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7389563/rt_hera_gnu_verify_against_existing.log)
[rt_hera_gnu_verify_against_existing_fail_test.log](https://github.com/NOAA-GSL/ufs-weather-model/files/7389564/rt_hera_gnu_verify_against_existing_fail_test.log)

These PRs are ready to merge.