### PR TITLE
Updates to the MYNN-EDMF

### DIFF
--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,15 +1,15 @@
-Tue Mar  8 20:57:43 UTC 2022
+Wed Mar 23 19:08:04 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 192 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v16_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 189 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 003 elapsed time 285 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 001 elapsed time 197 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v16_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 003 elapsed time 295 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
 Compile 004 elapsed time 98 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 222 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 006 elapsed time 119 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 005 elapsed time 225 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 006 elapsed time 127 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -56,14 +56,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 789.589459
-  0: The maximum resident set size (KB)                   = 439928
+  0: The total amount of wall time                        = 804.427693
+  0: The maximum resident set size (KB)                   = 439088
 
 Test 001 control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -102,14 +102,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 382.902934
-  0: The maximum resident set size (KB)                   = 183904
+  0: The total amount of wall time                        = 388.608212
+  0: The maximum resident set size (KB)                   = 179904
 
 Test 002 control_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_c48
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_c48
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -148,14 +148,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 670.619317
-0: The maximum resident set size (KB)                   = 694752
+0: The total amount of wall time                        = 677.242602
+0: The maximum resident set size (KB)                   = 695772
 
 Test 003 control_c48 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_stochy
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_stochy
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -166,14 +166,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 622.930523
-  0: The maximum resident set size (KB)                   = 444980
+  0: The total amount of wall time                        = 605.712186
+  0: The maximum resident set size (KB)                   = 441840
 
 Test 004 control_stochy PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_flake
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_flake
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -184,14 +184,14 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1388.222334
-  0: The maximum resident set size (KB)                   = 489084
+  0: The total amount of wall time                        = 1355.007440
+  0: The maximum resident set size (KB)                   = 489744
 
 Test 005 control_flake PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_rrtmgp
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_rrtmgp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_rrtmgp
 Checking test 006 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -202,14 +202,14 @@ Checking test 006 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 848.642934
-  0: The maximum resident set size (KB)                   = 540512
+  0: The total amount of wall time                        = 829.271310
+  0: The maximum resident set size (KB)                   = 542516
 
 Test 006 control_rrtmgp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_thompson
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_thompson
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_thompson
 Checking test 007 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -220,14 +220,14 @@ Checking test 007 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 990.363373
-  0: The maximum resident set size (KB)                   = 804384
+  0: The total amount of wall time                        = 987.805521
+  0: The maximum resident set size (KB)                   = 807196
 
 Test 007 control_thompson PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_thompson_no_aero
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_thompson_no_aero
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_thompson_no_aero
 Checking test 008 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -238,14 +238,14 @@ Checking test 008 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 964.775837
-  0: The maximum resident set size (KB)                   = 798228
+  0: The total amount of wall time                        = 968.878197
+  0: The maximum resident set size (KB)                   = 797936
 
 Test 008 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_ras
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_ras
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_ras
 Checking test 009 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -256,14 +256,14 @@ Checking test 009 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 801.504594
-  0: The maximum resident set size (KB)                   = 450060
+  0: The total amount of wall time                        = 837.283887
+  0: The maximum resident set size (KB)                   = 449656
 
 Test 009 control_ras PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_p8
 Checking test 010 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -310,14 +310,14 @@ Checking test 010 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 797.264729
-  0: The maximum resident set size (KB)                   = 478160
+  0: The total amount of wall time                        = 817.025847
+  0: The maximum resident set size (KB)                   = 477168
 
 Test 010 control_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rap_control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rap_control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rap_control
 Checking test 011 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -364,14 +364,14 @@ Checking test 011 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1407.396603
-  0: The maximum resident set size (KB)                   = 785984
+  0: The total amount of wall time                        = 1401.081659
+  0: The maximum resident set size (KB)                   = 788936
 
 Test 011 rap_control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rap_control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rap_2threads
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rap_2threads
 Checking test 012 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -418,14 +418,14 @@ Checking test 012 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1401.905636
- 0: The maximum resident set size (KB)                   = 851004
+ 0: The total amount of wall time                        = 1400.453999
+ 0: The maximum resident set size (KB)                   = 848892
 
 Test 012 rap_2threads PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rap_control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rap_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rap_restart
 Checking test 013 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -464,14 +464,14 @@ Checking test 013 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 677.764566
-  0: The maximum resident set size (KB)                   = 533772
+  0: The total amount of wall time                        = 686.555378
+  0: The maximum resident set size (KB)                   = 534196
 
 Test 013 rap_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rap_sfcdiff
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rap_sfcdiff
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rap_sfcdiff
 Checking test 014 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -518,14 +518,14 @@ Checking test 014 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1412.042063
-  0: The maximum resident set size (KB)                   = 791320
+  0: The total amount of wall time                        = 1393.471412
+  0: The maximum resident set size (KB)                   = 784664
 
 Test 014 rap_sfcdiff PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rap_sfcdiff
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rap_sfcdiff_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rap_sfcdiff_restart
 Checking test 015 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -564,14 +564,14 @@ Checking test 015 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 678.836028
-  0: The maximum resident set size (KB)                   = 532084
+  0: The total amount of wall time                        = 678.424034
+  0: The maximum resident set size (KB)                   = 535932
 
 Test 015 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/hrrr_control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/hrrr_control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/hrrr_control
 Checking test 016 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -618,14 +618,14 @@ Checking test 016 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1393.752869
-  0: The maximum resident set size (KB)                   = 788676
+  0: The total amount of wall time                        = 1355.527487
+  0: The maximum resident set size (KB)                   = 782228
 
 Test 016 hrrr_control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rrfs_v1beta
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rrfs_v1beta
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rrfs_v1beta
 Checking test 017 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -672,14 +672,14 @@ Checking test 017 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1361.471982
-  0: The maximum resident set size (KB)                   = 784380
+  0: The total amount of wall time                        = 1390.487267
+  0: The maximum resident set size (KB)                   = 784192
 
 Test 017 rrfs_v1beta PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rrfs_conus13km_hrrr_warm
 Checking test 018 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -688,14 +688,14 @@ Checking test 018 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1558.594911
-  0: The maximum resident set size (KB)                   = 628260
+  0: The total amount of wall time                        = 1556.107383
+  0: The maximum resident set size (KB)                   = 633584
 
 Test 018 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rrfs_conus13km_radar_tten_warm
 Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -704,250 +704,250 @@ Checking test 019 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1557.595277
-  0: The maximum resident set size (KB)                   = 630324
+  0: The total amount of wall time                        = 1576.390081
+  0: The maximum resident set size (KB)                   = 631984
 
 Test 019 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_debug
 Checking test 020 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 98.706750
-  0: The maximum resident set size (KB)                   = 440524
+  0: The total amount of wall time                        = 99.173154
+  0: The maximum resident set size (KB)                   = 440276
 
 Test 020 control_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_diag_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_diag_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_diag_debug
 Checking test 021 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 120.017989
-  0: The maximum resident set size (KB)                   = 495784
+  0: The total amount of wall time                        = 126.766639
+  0: The maximum resident set size (KB)                   = 496332
 
 Test 021 control_diag_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/fv3_regional_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/regional_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/regional_debug
 Checking test 022 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 125.682168
- 0: The maximum resident set size (KB)                   = 546104
+ 0: The total amount of wall time                        = 126.392238
+ 0: The maximum resident set size (KB)                   = 546164
 
 Test 022 regional_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rap_control_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rap_control_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rap_control_debug
 Checking test 023 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.629308
-  0: The maximum resident set size (KB)                   = 803216
+  0: The total amount of wall time                        = 170.449947
+  0: The maximum resident set size (KB)                   = 805008
 
 Test 023 rap_control_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rap_diag_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rap_diag_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rap_diag_debug
 Checking test 024 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 205.464478
-  0: The maximum resident set size (KB)                   = 887324
+  0: The total amount of wall time                        = 203.750197
+  0: The maximum resident set size (KB)                   = 892524
 
 Test 024 rap_diag_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 025 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 258.028896
-  0: The maximum resident set size (KB)                   = 805284
+  0: The total amount of wall time                        = 263.430805
+  0: The maximum resident set size (KB)                   = 803452
 
 Test 025 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rap_progcld_thompson_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rap_progcld_thompson_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rap_progcld_thompson_debug
 Checking test 026 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.616789
-  0: The maximum resident set size (KB)                   = 803980
+  0: The total amount of wall time                        = 166.253710
+  0: The maximum resident set size (KB)                   = 803652
 
 Test 026 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/rrfs_v1beta_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/rrfs_v1beta_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/rrfs_v1beta_debug
 Checking test 027 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 163.540709
-  0: The maximum resident set size (KB)                   = 802956
+  0: The total amount of wall time                        = 166.204267
+  0: The maximum resident set size (KB)                   = 803496
 
 Test 027 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_thompson_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_thompson_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_thompson_debug
 Checking test 028 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 112.620964
-  0: The maximum resident set size (KB)                   = 799336
+  0: The total amount of wall time                        = 112.127343
+  0: The maximum resident set size (KB)                   = 798424
 
 Test 028 control_thompson_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_thompson_no_aero_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_thompson_no_aero_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_thompson_no_aero_debug
 Checking test 029 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 108.401908
-  0: The maximum resident set size (KB)                   = 795864
+  0: The total amount of wall time                        = 111.413185
+  0: The maximum resident set size (KB)                   = 791332
 
 Test 029 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_thompson_debug_extdiag
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_thompson_extdiag_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_thompson_extdiag_debug
 Checking test 030 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 134.523597
-  0: The maximum resident set size (KB)                   = 827296
+  0: The total amount of wall time                        = 131.461634
+  0: The maximum resident set size (KB)                   = 829588
 
 Test 030 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_thompson_progcld_thompson_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_thompson_progcld_thompson_debug
 Checking test 031 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 113.782852
-  0: The maximum resident set size (KB)                   = 800264
+  0: The total amount of wall time                        = 115.562383
+  0: The maximum resident set size (KB)                   = 801552
 
 Test 031 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_rrtmgp_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_rrtmgp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_rrtmgp_debug
 Checking test 032 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 105.434311
-  0: The maximum resident set size (KB)                   = 539972
+  0: The total amount of wall time                        = 103.950916
+  0: The maximum resident set size (KB)                   = 537480
 
 Test 032 control_rrtmgp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_ras_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_ras_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_ras_debug
 Checking test 033 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 101.902804
-  0: The maximum resident set size (KB)                   = 451508
+  0: The total amount of wall time                        = 102.050742
+  0: The maximum resident set size (KB)                   = 447712
 
 Test 033 control_ras_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_stochy_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_stochy_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_stochy_debug
 Checking test 034 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 115.781242
-  0: The maximum resident set size (KB)                   = 440584
+  0: The total amount of wall time                        = 115.372581
+  0: The maximum resident set size (KB)                   = 444156
 
 Test 034 control_stochy_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_debug_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_debug_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_debug_p8
 Checking test 035 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 107.147993
-  0: The maximum resident set size (KB)                   = 480940
+  0: The total amount of wall time                        = 105.520606
+  0: The maximum resident set size (KB)                   = 475692
 
 Test 035 control_debug_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/control_wam_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/control_wam_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/control_wam_debug
 Checking test 036 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 179.551300
-  0: The maximum resident set size (KB)                   = 188580
+  0: The total amount of wall time                        = 179.037940
+  0: The maximum resident set size (KB)                   = 190112
 
 Test 036 control_wam_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/cpld_control_c96_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/cpld_control_c96_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/cpld_control_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/cpld_control_c96_p8
 Checking test 037 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1009,14 +1009,14 @@ Checking test 037 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1063.566450
-  0: The maximum resident set size (KB)                   = 501300
+  0: The total amount of wall time                        = 1089.814450
+  0: The maximum resident set size (KB)                   = 502080
 
 Test 037 cpld_control_c96_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/GNU/cpld_debug_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_299639/cpld_debug_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/GNU/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_72537/cpld_debug_p8
 Checking test 038 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1066,12 +1066,12 @@ Checking test 038 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 561.529615
-  0: The maximum resident set size (KB)                   = 517768
+  0: The total amount of wall time                        = 557.481215
+  0: The maximum resident set size (KB)                   = 512968
 
 Test 038 cpld_debug_p8 PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Mar  8 21:39:25 UTC 2022
-Elapsed time: 00h:41m:43s. Have a nice day!
+Wed Mar 23 19:52:07 UTC 2022
+Elapsed time: 00h:44m:04s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,24 +1,24 @@
-Tue Mar  8 19:13:42 UTC 2022
+Wed Mar 23 19:10:05 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 506 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 203 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 381 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 380 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 005 elapsed time 602 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 389 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 229 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 201 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 233 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 423 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 011 elapsed time 414 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 012 elapsed time 185 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 013 elapsed time 426 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 390 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 015 elapsed time 401 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 1697 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 1001 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1537 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 1054 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 005 elapsed time 1067 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 1181 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 801 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 776 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 752 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 1374 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 011 elapsed time 647 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 012 elapsed time 698 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 013 elapsed time 580 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 014 elapsed time 1220 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 015 elapsed time 1060 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_control_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -83,14 +83,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 212.420966
-  0: The maximum resident set size (KB)                   = 567448
+  0: The total amount of wall time                        = 218.772452
+  0: The maximum resident set size (KB)                   = 566188
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_2threads_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -143,14 +143,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 243.863986
-  0: The maximum resident set size (KB)                   = 646264
+  0: The total amount of wall time                        = 245.501657
+  0: The maximum resident set size (KB)                   = 644708
 
 Test 002 cpld_2threads_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_decomp_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -203,14 +203,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 216.500771
-  0: The maximum resident set size (KB)                   = 560192
+  0: The total amount of wall time                        = 214.158400
+  0: The maximum resident set size (KB)                   = 564540
 
 Test 003 cpld_decomp_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_mpi_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -263,14 +263,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 181.144306
-  0: The maximum resident set size (KB)                   = 538080
+  0: The total amount of wall time                        = 187.279021
+  0: The maximum resident set size (KB)                   = 536708
 
 Test 004 cpld_mpi_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_p7_rrtmgp
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_control_p7_rrtmgp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_p7_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_control_p7_rrtmgp
 Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -323,14 +323,14 @@ Checking test 005 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 252.472261
-  0: The maximum resident set size (KB)                   = 660776
+  0: The total amount of wall time                        = 253.095657
+  0: The maximum resident set size (KB)                   = 665256
 
 Test 005 cpld_control_p7_rrtmgp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_bmark_p7
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_bmark_p7
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_bmark_p7
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_bmark_p7
 Checking test 006 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -375,14 +375,14 @@ Checking test 006 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 849.745992
-  0: The maximum resident set size (KB)                   = 1235164
+  0: The total amount of wall time                        = 838.732780
+  0: The maximum resident set size (KB)                   = 1234024
 
 Test 006 cpld_bmark_p7 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_bmark_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_bmark_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_bmark_p8
 Checking test 007 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -427,14 +427,14 @@ Checking test 007 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 846.182157
-  0: The maximum resident set size (KB)                   = 1237216
+  0: The total amount of wall time                        = 850.544828
+  0: The maximum resident set size (KB)                   = 1233520
 
 Test 007 cpld_bmark_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_bmark_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_bmark_mpi_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_bmark_mpi_p8
 Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -479,14 +479,14 @@ Checking test 008 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 826.803296
-  0: The maximum resident set size (KB)                   = 1249076
+  0: The total amount of wall time                        = 818.952276
+  0: The maximum resident set size (KB)                   = 1239280
 
 Test 008 cpld_bmark_mpi_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_c96_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_control_c96_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_control_c96_p8
 Checking test 009 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -548,14 +548,14 @@ Checking test 009 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 203.502075
-  0: The maximum resident set size (KB)                   = 557168
+  0: The total amount of wall time                        = 202.453236
+  0: The maximum resident set size (KB)                   = 557676
 
 Test 009 cpld_control_c96_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_c96_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_restart_c96_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_restart_c96_p8
 Checking test 010 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -605,14 +605,14 @@ Checking test 010 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 113.602514
-  0: The maximum resident set size (KB)                   = 324800
+  0: The total amount of wall time                        = 110.347267
+  0: The maximum resident set size (KB)                   = 323768
 
 Test 010 cpld_restart_c96_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_control_c192_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_control_c192_p8
 Checking test 011 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -662,14 +662,14 @@ Checking test 011 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 850.120978
-  0: The maximum resident set size (KB)                   = 730300
+  0: The total amount of wall time                        = 844.219784
+  0: The maximum resident set size (KB)                   = 731116
 
 Test 011 cpld_control_c192_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_c192_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_restart_c192_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_restart_c192_p8
 Checking test 012 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -719,14 +719,14 @@ Checking test 012 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 525.790214
-  0: The maximum resident set size (KB)                   = 835340
+  0: The total amount of wall time                        = 524.470489
+  0: The maximum resident set size (KB)                   = 834488
 
 Test 012 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_c384_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_control_c384_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_c384_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_control_c384_p8
 Checking test 013 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -769,14 +769,14 @@ Checking test 013 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 973.919358
-  0: The maximum resident set size (KB)                   = 1247740
+  0: The total amount of wall time                        = 967.363607
+  0: The maximum resident set size (KB)                   = 1249908
 
 Test 013 cpld_control_c384_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_c384_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_restart_c384_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_c384_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_restart_c384_p8
 Checking test 014 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -819,14 +819,14 @@ Checking test 014 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 540.309194
-  0: The maximum resident set size (KB)                   = 1208920
+  0: The total amount of wall time                        = 539.962383
+  0: The maximum resident set size (KB)                   = 1207536
 
 Test 014 cpld_restart_c384_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_debug_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/cpld_debug_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/cpld_debug_p8
 Checking test 015 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -876,14 +876,14 @@ Checking test 015 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 608.177985
-  0: The maximum resident set size (KB)                   = 615200
+  0: The total amount of wall time                        = 605.948401
+  0: The maximum resident set size (KB)                   = 612428
 
 Test 015 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control
 Checking test 016 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -930,14 +930,14 @@ Checking test 016 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 128.184976
-  0: The maximum resident set size (KB)                   = 461240
+  0: The total amount of wall time                        = 127.967953
+  0: The maximum resident set size (KB)                   = 461268
 
 Test 016 control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_decomp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_decomp
 Checking test 017 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -980,28 +980,28 @@ Checking test 017 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 129.989824
-  0: The maximum resident set size (KB)                   = 465176
+  0: The total amount of wall time                        = 133.366690
+  0: The maximum resident set size (KB)                   = 463236
 
 Test 017 control_decomp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_2dwrtdecomp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_2dwrtdecomp
 Checking test 018 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 116.332529
-  0: The maximum resident set size (KB)                   = 461084
+  0: The total amount of wall time                        = 117.053128
+  0: The maximum resident set size (KB)                   = 462732
 
 Test 018 control_2dwrtdecomp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_2threads
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_2threads
 Checking test 019 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1044,14 +1044,14 @@ Checking test 019 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 150.097470
- 0: The maximum resident set size (KB)                   = 512456
+ 0: The total amount of wall time                        = 149.466927
+ 0: The maximum resident set size (KB)                   = 514928
 
 Test 019 control_2threads PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_restart
 Checking test 020 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1090,14 +1090,14 @@ Checking test 020 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 66.801766
-  0: The maximum resident set size (KB)                   = 205032
+  0: The total amount of wall time                        = 66.893413
+  0: The maximum resident set size (KB)                   = 205668
 
 Test 020 control_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_fhzero
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_fhzero
 Checking test 021 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1140,14 +1140,14 @@ Checking test 021 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 121.399899
-  0: The maximum resident set size (KB)                   = 460484
+  0: The total amount of wall time                        = 120.320545
+  0: The maximum resident set size (KB)                   = 462348
 
 Test 021 control_fhzero PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_CubedSphereGrid
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_CubedSphereGrid
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_CubedSphereGrid
 Checking test 022 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1174,14 +1174,14 @@ Checking test 022 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 123.484594
-  0: The maximum resident set size (KB)                   = 463616
+  0: The total amount of wall time                        = 121.982406
+  0: The maximum resident set size (KB)                   = 464104
 
 Test 022 control_CubedSphereGrid PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_latlon
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_latlon
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_latlon
 Checking test 023 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1192,17 +1192,17 @@ Checking test 023 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 123.744512
-  0: The maximum resident set size (KB)                   = 462584
+  0: The total amount of wall time                        = 124.758566
+  0: The maximum resident set size (KB)                   = 464016
 
 Test 023 control_latlon PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_wrtGauss_netcdf_parallel
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_wrtGauss_netcdf_parallel
 Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc .........OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
@@ -1210,14 +1210,14 @@ Checking test 024 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 121.333864
-  0: The maximum resident set size (KB)                   = 463528
+  0: The total amount of wall time                        = 126.440937
+  0: The maximum resident set size (KB)                   = 464892
 
 Test 024 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_c48
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_c48
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_c48
 Checking test 025 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1256,14 +1256,14 @@ Checking test 025 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 312.384497
-0: The maximum resident set size (KB)                   = 663156
+0: The total amount of wall time                        = 307.972586
+0: The maximum resident set size (KB)                   = 663532
 
 Test 025 control_c48 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_c192
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_c192
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_c192
 Checking test 026 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1274,14 +1274,14 @@ Checking test 026 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 461.869373
-  0: The maximum resident set size (KB)                   = 562008
+  0: The total amount of wall time                        = 460.961916
+  0: The maximum resident set size (KB)                   = 560644
 
 Test 026 control_c192 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_c384
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_c384
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_c384
 Checking test 027 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1292,14 +1292,14 @@ Checking test 027 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 759.922928
-  0: The maximum resident set size (KB)                   = 823644
+  0: The total amount of wall time                        = 754.633666
+  0: The maximum resident set size (KB)                   = 826112
 
 Test 027 control_c384 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_c384gdas
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_c384gdas
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_c384gdas
 Checking test 028 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1342,14 +1342,14 @@ Checking test 028 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 675.806530
-  0: The maximum resident set size (KB)                   = 972944
+  0: The total amount of wall time                        = 668.831239
+  0: The maximum resident set size (KB)                   = 971132
 
 Test 028 control_c384gdas PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_stochy
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_stochy
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_stochy
 Checking test 029 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1360,28 +1360,28 @@ Checking test 029 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 81.711982
-  0: The maximum resident set size (KB)                   = 464740
+  0: The total amount of wall time                        = 82.644439
+  0: The maximum resident set size (KB)                   = 468696
 
 Test 029 control_stochy PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_stochy
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_stochy_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_stochy_restart
 Checking test 030 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 43.169827
-  0: The maximum resident set size (KB)                   = 244764
+  0: The total amount of wall time                        = 44.796203
+  0: The maximum resident set size (KB)                   = 247404
 
 Test 030 control_stochy_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_lndp
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_lndp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_lndp
 Checking test 031 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1392,14 +1392,14 @@ Checking test 031 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 73.138178
-  0: The maximum resident set size (KB)                   = 465216
+  0: The total amount of wall time                        = 73.241273
+  0: The maximum resident set size (KB)                   = 464728
 
 Test 031 control_lndp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_iovr4
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_iovr4
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_iovr4
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_iovr4
 Checking test 032 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1414,14 +1414,14 @@ Checking test 032 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 126.314918
-  0: The maximum resident set size (KB)                   = 459900
+  0: The total amount of wall time                        = 122.429291
+  0: The maximum resident set size (KB)                   = 462612
 
 Test 032 control_iovr4 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_iovr5
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_iovr5
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_iovr5
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_iovr5
 Checking test 033 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1436,14 +1436,14 @@ Checking test 033 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 122.720162
-  0: The maximum resident set size (KB)                   = 460964
+  0: The total amount of wall time                        = 125.767367
+  0: The maximum resident set size (KB)                   = 464464
 
 Test 033 control_iovr5 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_p8
 Checking test 034 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1490,14 +1490,14 @@ Checking test 034 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 140.959053
-  0: The maximum resident set size (KB)                   = 495564
+  0: The total amount of wall time                        = 142.681894
+  0: The maximum resident set size (KB)                   = 490800
 
 Test 034 control_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_restart_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_restart_p8
 Checking test 035 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1536,14 +1536,14 @@ Checking test 035 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 74.830127
-  0: The maximum resident set size (KB)                   = 293156
+  0: The total amount of wall time                        = 76.080812
+  0: The maximum resident set size (KB)                   = 292140
 
 Test 035 control_restart_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_decomp_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_decomp_p8
 Checking test 036 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1586,14 +1586,14 @@ Checking test 036 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 142.449396
-  0: The maximum resident set size (KB)                   = 487480
+  0: The total amount of wall time                        = 143.394095
+  0: The maximum resident set size (KB)                   = 485312
 
 Test 036 control_decomp_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_2threads_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_2threads_p8
 Checking test 037 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1636,14 +1636,14 @@ Checking test 037 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 168.537950
- 0: The maximum resident set size (KB)                   = 566168
+ 0: The total amount of wall time                        = 170.521563
+ 0: The maximum resident set size (KB)                   = 567960
 
 Test 037 control_2threads_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_p7_rrtmgp
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_p7_rrtmgp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_p7_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_p7_rrtmgp
 Checking test 038 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1690,14 +1690,14 @@ Checking test 038 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 174.670188
-  0: The maximum resident set size (KB)                   = 591368
+  0: The total amount of wall time                        = 173.832647
+  0: The maximum resident set size (KB)                   = 592800
 
 Test 038 control_p7_rrtmgp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/regional_control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/regional_control
 Checking test 039 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1708,42 +1708,42 @@ Checking test 039 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 300.243681
- 0: The maximum resident set size (KB)                   = 581824
+ 0: The total amount of wall time                        = 299.989539
+ 0: The maximum resident set size (KB)                   = 586404
 
 Test 039 regional_control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/regional_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/regional_restart
 Checking test 040 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 165.142531
- 0: The maximum resident set size (KB)                   = 579068
+ 0: The total amount of wall time                        = 163.922312
+ 0: The maximum resident set size (KB)                   = 580184
 
 Test 040 regional_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/regional_control_2dwrtdecomp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/regional_control_2dwrtdecomp
 Checking test 041 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 299.246533
- 0: The maximum resident set size (KB)                   = 580420
+ 0: The total amount of wall time                        = 298.937200
+ 0: The maximum resident set size (KB)                   = 578548
 
 Test 041 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_noquilt
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/regional_noquilt
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/regional_noquilt
 Checking test 042 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1751,14 +1751,14 @@ Checking test 042 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 312.746055
- 0: The maximum resident set size (KB)                   = 596516
+ 0: The total amount of wall time                        = 311.790248
+ 0: The maximum resident set size (KB)                   = 594992
 
 Test 042 regional_noquilt PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/regional_2threads
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/regional_2threads
 Checking test 043 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1769,14 +1769,14 @@ Checking test 043 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 234.536061
- 0: The maximum resident set size (KB)                   = 572992
+ 0: The total amount of wall time                        = 234.530393
+ 0: The maximum resident set size (KB)                   = 577208
 
 Test 043 regional_2threads PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_hafs
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/regional_hafs
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_hafs
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/regional_hafs
 Checking test 044 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1785,28 +1785,28 @@ Checking test 044 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 295.084824
- 0: The maximum resident set size (KB)                   = 577040
+ 0: The total amount of wall time                        = 294.266022
+ 0: The maximum resident set size (KB)                   = 578272
 
 Test 044 regional_hafs PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_netcdf_parallel
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/regional_netcdf_parallel
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/regional_netcdf_parallel
 Checking test 045 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 295.167219
- 0: The maximum resident set size (KB)                   = 574776
+ 0: The total amount of wall time                        = 294.444523
+ 0: The maximum resident set size (KB)                   = 575136
 
 Test 045 regional_netcdf_parallel PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_RRTMGP
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/regional_RRTMGP
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_RRTMGP
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/regional_RRTMGP
 Checking test 046 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1817,14 +1817,14 @@ Checking test 046 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 374.643827
- 0: The maximum resident set size (KB)                   = 701620
+ 0: The total amount of wall time                        = 372.364796
+ 0: The maximum resident set size (KB)                   = 699948
 
 Test 046 regional_RRTMGP PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_control
 Checking test 047 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1871,14 +1871,14 @@ Checking test 047 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 353.623952
-  0: The maximum resident set size (KB)                   = 835136
+  0: The total amount of wall time                        = 358.846038
+  0: The maximum resident set size (KB)                   = 833368
 
 Test 047 rap_control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/regional_spp_sppt_shum_skeb
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/regional_spp_sppt_shum_skeb
 Checking test 048 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1889,14 +1889,14 @@ Checking test 048 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 278.762557
-  0: The maximum resident set size (KB)                   = 922044
+  0: The total amount of wall time                        = 277.910941
+  0: The maximum resident set size (KB)                   = 922176
 
 Test 048 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_2threads
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_2threads
 Checking test 049 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1943,14 +1943,14 @@ Checking test 049 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 438.164248
- 0: The maximum resident set size (KB)                   = 898964
+ 0: The total amount of wall time                        = 437.712423
+ 0: The maximum resident set size (KB)                   = 896068
 
 Test 049 rap_2threads PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_restart
 Checking test 050 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1989,14 +1989,14 @@ Checking test 050 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 183.874665
-  0: The maximum resident set size (KB)                   = 582768
+  0: The total amount of wall time                        = 183.049008
+  0: The maximum resident set size (KB)                   = 584008
 
 Test 050 rap_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_sfcdiff
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_sfcdiff
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_sfcdiff
 Checking test 051 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2043,14 +2043,14 @@ Checking test 051 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 357.371525
-  0: The maximum resident set size (KB)                   = 830052
+  0: The total amount of wall time                        = 350.621892
+  0: The maximum resident set size (KB)                   = 834332
 
 Test 051 rap_sfcdiff PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_sfcdiff
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_sfcdiff_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_sfcdiff_restart
 Checking test 052 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2089,14 +2089,14 @@ Checking test 052 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 181.571797
-  0: The maximum resident set size (KB)                   = 587416
+  0: The total amount of wall time                        = 178.640286
+  0: The maximum resident set size (KB)                   = 586336
 
 Test 052 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hrrr_control
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hrrr_control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hrrr_control
 Checking test 053 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2143,14 +2143,14 @@ Checking test 053 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 354.035860
-  0: The maximum resident set size (KB)                   = 828144
+  0: The total amount of wall time                        = 335.041827
+  0: The maximum resident set size (KB)                   = 832104
 
 Test 053 hrrr_control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rrfs_v1beta
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rrfs_v1beta
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rrfs_v1beta
 Checking test 054 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2197,14 +2197,14 @@ Checking test 054 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 346.592861
-  0: The maximum resident set size (KB)                   = 829844
+  0: The total amount of wall time                        = 354.978864
+  0: The maximum resident set size (KB)                   = 827288
 
 Test 054 rrfs_v1beta PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2213,14 +2213,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 164.128759
-  0: The maximum resident set size (KB)                   = 661976
+  0: The total amount of wall time                        = 158.187739
+  0: The maximum resident set size (KB)                   = 665408
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2229,14 +2229,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 159.888818
-  0: The maximum resident set size (KB)                   = 665776
+  0: The total amount of wall time                        = 165.126987
+  0: The maximum resident set size (KB)                   = 668472
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_rrtmgp
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_rrtmgp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_rrtmgp
 Checking test 057 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2247,14 +2247,14 @@ Checking test 057 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 186.135673
-  0: The maximum resident set size (KB)                   = 592784
+  0: The total amount of wall time                        = 192.090609
+  0: The maximum resident set size (KB)                   = 590412
 
 Test 057 control_rrtmgp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_rrtmgp_c192
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_rrtmgp_c192
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_rrtmgp_c192
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_rrtmgp_c192
 Checking test 058 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2265,14 +2265,14 @@ Checking test 058 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 509.138721
-  0: The maximum resident set size (KB)                   = 802560
+  0: The total amount of wall time                        = 506.909365
+  0: The maximum resident set size (KB)                   = 801484
 
 Test 058 control_rrtmgp_c192 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_csawmg
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_csawmg
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_csawmg
 Checking test 059 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2283,14 +2283,14 @@ Checking test 059 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 312.414375
-  0: The maximum resident set size (KB)                   = 529728
+  0: The total amount of wall time                        = 313.212465
+  0: The maximum resident set size (KB)                   = 530448
 
 Test 059 control_csawmg PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_csawmgt
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_csawmgt
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_csawmgt
 Checking test 060 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2301,14 +2301,14 @@ Checking test 060 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 303.831856
-  0: The maximum resident set size (KB)                   = 532280
+  0: The total amount of wall time                        = 308.624778
+  0: The maximum resident set size (KB)                   = 532628
 
 Test 060 control_csawmgt PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_flake
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_flake
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_flake
 Checking test 061 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2319,14 +2319,14 @@ Checking test 061 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 223.634759
-  0: The maximum resident set size (KB)                   = 536144
+  0: The total amount of wall time                        = 223.269181
+  0: The maximum resident set size (KB)                   = 534048
 
 Test 061 control_flake PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_ras
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_ras
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_ras
 Checking test 062 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2337,14 +2337,14 @@ Checking test 062 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 163.206797
-  0: The maximum resident set size (KB)                   = 491160
+  0: The total amount of wall time                        = 168.843426
+  0: The maximum resident set size (KB)                   = 492704
 
 Test 062 control_ras PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_thompson
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_thompson
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_thompson
 Checking test 063 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2355,14 +2355,14 @@ Checking test 063 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 207.031472
-  0: The maximum resident set size (KB)                   = 847460
+  0: The total amount of wall time                        = 213.443930
+  0: The maximum resident set size (KB)                   = 846480
 
 Test 063 control_thompson PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_thompson_no_aero
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_thompson_no_aero
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_thompson_no_aero
 Checking test 064 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2373,54 +2373,54 @@ Checking test 064 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 196.489374
-  0: The maximum resident set size (KB)                   = 840660
+  0: The total amount of wall time                        = 199.450162
+  0: The maximum resident set size (KB)                   = 839088
 
 Test 064 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_wam_repro
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_wam_repro
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_wam_repro
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_wam_repro
 Checking test 065 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 118.852214
-  0: The maximum resident set size (KB)                   = 230336
+  0: The total amount of wall time                        = 113.958804
+  0: The maximum resident set size (KB)                   = 228144
 
 Test 065 control_wam PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_debug
 Checking test 066 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 139.798400
-  0: The maximum resident set size (KB)                   = 530992
+  0: The total amount of wall time                        = 143.388006
+  0: The maximum resident set size (KB)                   = 534944
 
 Test 066 control_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_2threads_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_2threads_debug
 Checking test 067 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 212.160040
- 0: The maximum resident set size (KB)                   = 581884
+ 0: The total amount of wall time                        = 213.178271
+ 0: The maximum resident set size (KB)                   = 581972
 
 Test 067 control_2threads_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_CubedSphereGrid_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_CubedSphereGrid_debug
 Checking test 068 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2447,428 +2447,428 @@ Checking test 068 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 155.810985
-  0: The maximum resident set size (KB)                   = 531292
+  0: The total amount of wall time                        = 152.933745
+  0: The maximum resident set size (KB)                   = 530880
 
 Test 068 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_wrtGauss_netcdf_parallel_debug
 Checking test 069 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 142.894513
-  0: The maximum resident set size (KB)                   = 533812
+  0: The total amount of wall time                        = 141.682169
+  0: The maximum resident set size (KB)                   = 529844
 
 Test 069 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_stochy_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_stochy_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_stochy_debug
 Checking test 070 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 163.485587
-  0: The maximum resident set size (KB)                   = 535468
+  0: The total amount of wall time                        = 164.634655
+  0: The maximum resident set size (KB)                   = 538408
 
 Test 070 control_stochy_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_lndp_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_lndp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_lndp_debug
 Checking test 071 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 148.272813
-  0: The maximum resident set size (KB)                   = 533584
+  0: The total amount of wall time                        = 145.069561
+  0: The maximum resident set size (KB)                   = 538076
 
 Test 071 control_lndp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_rrtmgp_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_rrtmgp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_rrtmgp_debug
 Checking test 072 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 154.005076
-  0: The maximum resident set size (KB)                   = 637228
+  0: The total amount of wall time                        = 158.179311
+  0: The maximum resident set size (KB)                   = 638232
 
 Test 072 control_rrtmgp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_csawmg_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_csawmg_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_csawmg_debug
 Checking test 073 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 220.861862
-  0: The maximum resident set size (KB)                   = 574220
+  0: The total amount of wall time                        = 220.242282
+  0: The maximum resident set size (KB)                   = 572128
 
 Test 073 control_csawmg_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_csawmgt_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_csawmgt_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_csawmgt_debug
 Checking test 074 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 220.728710
-  0: The maximum resident set size (KB)                   = 573884
+  0: The total amount of wall time                        = 219.537904
+  0: The maximum resident set size (KB)                   = 572676
 
 Test 074 control_csawmgt_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_ras_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_ras_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_ras_debug
 Checking test 075 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 146.503023
-  0: The maximum resident set size (KB)                   = 541620
+  0: The total amount of wall time                        = 147.240562
+  0: The maximum resident set size (KB)                   = 546724
 
 Test 075 control_ras_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_diag_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_diag_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_diag_debug
 Checking test 076 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 150.591064
-  0: The maximum resident set size (KB)                   = 586628
+  0: The total amount of wall time                        = 151.191800
+  0: The maximum resident set size (KB)                   = 588832
 
 Test 076 control_diag_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_debug_p8
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_debug_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_debug_p8
 Checking test 077 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.365231
-  0: The maximum resident set size (KB)                   = 558100
+  0: The total amount of wall time                        = 150.964144
+  0: The maximum resident set size (KB)                   = 554356
 
 Test 077 control_debug_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_thompson_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_thompson_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_thompson_debug
 Checking test 078 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.366889
-  0: The maximum resident set size (KB)                   = 889300
+  0: The total amount of wall time                        = 166.205679
+  0: The maximum resident set size (KB)                   = 888012
 
 Test 078 control_thompson_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_thompson_no_aero_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_thompson_no_aero_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_thompson_no_aero_debug
 Checking test 079 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 159.433629
-  0: The maximum resident set size (KB)                   = 888828
+  0: The total amount of wall time                        = 159.449962
+  0: The maximum resident set size (KB)                   = 886968
 
 Test 079 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_thompson_debug_extdiag
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_thompson_extdiag_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_thompson_extdiag_debug
 Checking test 080 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 174.336191
-  0: The maximum resident set size (KB)                   = 922560
+  0: The total amount of wall time                        = 174.538824
+  0: The maximum resident set size (KB)                   = 919312
 
 Test 080 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_thompson_progcld_thompson_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_thompson_progcld_thompson_debug
 Checking test 081 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 167.389038
-  0: The maximum resident set size (KB)                   = 889588
+  0: The total amount of wall time                        = 167.298010
+  0: The maximum resident set size (KB)                   = 893132
 
 Test 081 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/regional_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/regional_debug
 Checking test 082 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 233.861521
- 0: The maximum resident set size (KB)                   = 602828
+ 0: The total amount of wall time                        = 233.044132
+ 0: The maximum resident set size (KB)                   = 607208
 
 Test 082 regional_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_control_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_control_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_control_debug
 Checking test 083 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 260.452245
-  0: The maximum resident set size (KB)                   = 899532
+  0: The total amount of wall time                        = 259.491900
+  0: The maximum resident set size (KB)                   = 898296
 
 Test 083 rap_control_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_control_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_unified_drag_suite_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_unified_drag_suite_debug
 Checking test 084 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 256.870265
-  0: The maximum resident set size (KB)                   = 900388
+  0: The total amount of wall time                        = 258.641416
+  0: The maximum resident set size (KB)                   = 898212
 
 Test 084 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_diag_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_diag_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_diag_debug
 Checking test 085 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 274.364426
-  0: The maximum resident set size (KB)                   = 985820
+  0: The total amount of wall time                        = 272.702613
+  0: The maximum resident set size (KB)                   = 977992
 
 Test 085 rap_diag_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_cires_ugwp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_cires_ugwp_debug
 Checking test 086 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 265.101946
-  0: The maximum resident set size (KB)                   = 903076
+  0: The total amount of wall time                        = 267.975958
+  0: The maximum resident set size (KB)                   = 903364
 
 Test 086 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_unified_ugwp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_unified_ugwp_debug
 Checking test 087 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 261.190037
-  0: The maximum resident set size (KB)                   = 897504
+  0: The total amount of wall time                        = 265.146794
+  0: The maximum resident set size (KB)                   = 900220
 
 Test 087 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_noah_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_noah_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_noah_debug
 Checking test 088 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 253.350540
-  0: The maximum resident set size (KB)                   = 899020
+  0: The total amount of wall time                        = 255.072832
+  0: The maximum resident set size (KB)                   = 897272
 
 Test 088 rap_noah_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_rrtmgp_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_rrtmgp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_rrtmgp_debug
 Checking test 089 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 443.193985
-  0: The maximum resident set size (KB)                   = 1004804
+  0: The total amount of wall time                        = 432.408581
+  0: The maximum resident set size (KB)                   = 1007916
 
 Test 089 rap_rrtmgp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_lndp_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_lndp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_lndp_debug
 Checking test 090 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 264.698866
-  0: The maximum resident set size (KB)                   = 899904
+  0: The total amount of wall time                        = 260.061014
+  0: The maximum resident set size (KB)                   = 901808
 
 Test 090 rap_lndp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_sfcdiff_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_sfcdiff_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_sfcdiff_debug
 Checking test 091 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.730614
-  0: The maximum resident set size (KB)                   = 898692
+  0: The total amount of wall time                        = 259.144805
+  0: The maximum resident set size (KB)                   = 901404
 
 Test 091 rap_sfcdiff_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_flake_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_flake_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_flake_debug
 Checking test 092 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 257.164843
-  0: The maximum resident set size (KB)                   = 896192
+  0: The total amount of wall time                        = 258.975060
+  0: The maximum resident set size (KB)                   = 900876
 
 Test 092 rap_flake_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 093 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 428.749526
-  0: The maximum resident set size (KB)                   = 897564
+  0: The total amount of wall time                        = 423.239183
+  0: The maximum resident set size (KB)                   = 894416
 
 Test 093 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_progcld_thompson_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rap_progcld_thompson_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rap_progcld_thompson_debug
 Checking test 094 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 256.859128
-  0: The maximum resident set size (KB)                   = 902476
+  0: The total amount of wall time                        = 258.891617
+  0: The maximum resident set size (KB)                   = 897772
 
 Test 094 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rrfs_v1beta_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/rrfs_v1beta_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/rrfs_v1beta_debug
 Checking test 095 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 256.489009
-  0: The maximum resident set size (KB)                   = 894024
+  0: The total amount of wall time                        = 255.340288
+  0: The maximum resident set size (KB)                   = 895868
 
 Test 095 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_wam_debug
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_wam_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_wam_debug
 Checking test 096 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 277.961941
-  0: The maximum resident set size (KB)                   = 251428
+  0: The total amount of wall time                        = 276.485430
+  0: The maximum resident set size (KB)                   = 252340
 
 Test 096 control_wam_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_atm
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hafs_regional_atm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hafs_regional_atm
 Checking test 097 hafs_regional_atm results ....
  Comparing atmf006.nc ............ALT CHECK......OK
- Comparing sfcf006.nc .........OK
+ Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 261.196011
-  0: The maximum resident set size (KB)                   = 703848
+  0: The total amount of wall time                        = 252.452303
+  0: The maximum resident set size (KB)                   = 709116
 
 Test 097 hafs_regional_atm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hafs_regional_atm_thompson_gfdlsf
 Checking test 098 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 309.043766
-  0: The maximum resident set size (KB)                   = 1064868
+  0: The total amount of wall time                        = 320.266603
+  0: The maximum resident set size (KB)                   = 1063284
 
 Test 098 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hafs_regional_atm_ocn
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hafs_regional_atm_ocn
 Checking test 099 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2877,28 +2877,28 @@ Checking test 099 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 348.258850
-  0: The maximum resident set size (KB)                   = 717980
+  0: The total amount of wall time                        = 347.363664
+  0: The maximum resident set size (KB)                   = 717236
 
 Test 099 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_atm_wav
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hafs_regional_atm_wav
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hafs_regional_atm_wav
 Checking test 100 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 812.573228
-  0: The maximum resident set size (KB)                   = 721632
+  0: The total amount of wall time                        = 840.396232
+  0: The maximum resident set size (KB)                   = 719856
 
 Test 100 hafs_regional_atm_wav PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hafs_regional_atm_ocn_wav
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hafs_regional_atm_ocn_wav
 Checking test 101 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2907,28 +2907,28 @@ Checking test 101 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 914.680922
-  0: The maximum resident set size (KB)                   = 727172
+  0: The total amount of wall time                        = 931.464415
+  0: The maximum resident set size (KB)                   = 721044
 
 Test 101 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hafs_regional_1nest_atm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hafs_regional_1nest_atm
 Checking test 102 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc ............ALT CHECK......OK
- Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
+ Comparing atm.nest02.f006.nc .........OK
+ Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 408.744223
-  0: The maximum resident set size (KB)                   = 310976
+  0: The total amount of wall time                        = 409.135999
+  0: The maximum resident set size (KB)                   = 308696
 
 Test 102 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hafs_regional_telescopic_2nests_atm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hafs_regional_telescopic_2nests_atm
 Checking test 103 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2937,28 +2937,28 @@ Checking test 103 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 427.081618
-  0: The maximum resident set size (KB)                   = 321920
+  0: The total amount of wall time                        = 425.450373
+  0: The maximum resident set size (KB)                   = 322612
 
 Test 103 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_global_1nest_atm
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hafs_global_1nest_atm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hafs_global_1nest_atm
 Checking test 104 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 191.797892
-  0: The maximum resident set size (KB)                   = 199056
+  0: The total amount of wall time                        = 191.513406
+  0: The maximum resident set size (KB)                   = 197904
 
 Test 104 hafs_global_1nest_atm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hafs_global_multiple_4nests_atm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hafs_global_multiple_4nests_atm
 Checking test 105 hafs_global_multiple_4nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2971,14 +2971,14 @@ Checking test 105 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc .........OK
 
-  0: The total amount of wall time                        = 531.764979
-  0: The maximum resident set size (KB)                   = 254848
+  0: The total amount of wall time                        = 529.856054
+  0: The maximum resident set size (KB)                   = 255868
 
 Test 105 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_docn
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hafs_regional_docn
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hafs_regional_docn
 Checking test 106 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -2986,14 +2986,14 @@ Checking test 106 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 329.894713
-  0: The maximum resident set size (KB)                   = 721504
+  0: The total amount of wall time                        = 326.113502
+  0: The maximum resident set size (KB)                   = 723852
 
 Test 106 hafs_regional_docn PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hafs_regional_docn_oisst
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hafs_regional_docn_oisst
 Checking test 107 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3001,105 +3001,105 @@ Checking test 107 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 327.543198
-  0: The maximum resident set size (KB)                   = 719576
+  0: The total amount of wall time                        = 324.382938
+  0: The maximum resident set size (KB)                   = 729420
 
 Test 107 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/hafs_regional_datm_cdeps
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/hafs_regional_datm_cdeps
 Checking test 108 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1017.262552
-  0: The maximum resident set size (KB)                   = 853648
+  0: The total amount of wall time                        = 940.492427
+  0: The maximum resident set size (KB)                   = 854088
 
 Test 108 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/datm_cdeps_control_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/datm_cdeps_control_cfsr
 Checking test 109 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.497519
- 0: The maximum resident set size (KB)                   = 717548
+ 0: The total amount of wall time                        = 139.168224
+ 0: The maximum resident set size (KB)                   = 717124
 
 Test 109 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/datm_cdeps_restart_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/datm_cdeps_restart_cfsr
 Checking test 110 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 80.561452
- 0: The maximum resident set size (KB)                   = 719076
+ 0: The total amount of wall time                        = 82.165631
+ 0: The maximum resident set size (KB)                   = 717436
 
 Test 110 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/datm_cdeps_control_gefs
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/datm_cdeps_control_gefs
 Checking test 111 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.403928
- 0: The maximum resident set size (KB)                   = 619432
+ 0: The total amount of wall time                        = 137.096908
+ 0: The maximum resident set size (KB)                   = 619572
 
 Test 111 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/datm_cdeps_stochy_gefs
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/datm_cdeps_stochy_gefs
 Checking test 112 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 138.066502
- 0: The maximum resident set size (KB)                   = 619384
+ 0: The total amount of wall time                        = 139.555040
+ 0: The maximum resident set size (KB)                   = 619556
 
 Test 112 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/datm_cdeps_bulk_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/datm_cdeps_bulk_cfsr
 Checking test 113 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.323813
- 0: The maximum resident set size (KB)                   = 717924
+ 0: The total amount of wall time                        = 141.561760
+ 0: The maximum resident set size (KB)                   = 717328
 
 Test 113 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/datm_cdeps_bulk_gefs
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/datm_cdeps_bulk_gefs
 Checking test 114 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 136.647368
- 0: The maximum resident set size (KB)                   = 619668
+ 0: The total amount of wall time                        = 136.723914
+ 0: The maximum resident set size (KB)                   = 618348
 
 Test 114 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/datm_cdeps_mx025_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/datm_cdeps_mx025_cfsr
 Checking test 115 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3108,14 +3108,14 @@ Checking test 115 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 301.717753
-  0: The maximum resident set size (KB)                   = 559060
+  0: The total amount of wall time                        = 305.354754
+  0: The maximum resident set size (KB)                   = 566444
 
 Test 115 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/datm_cdeps_mx025_gefs
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/datm_cdeps_mx025_gefs
 Checking test 116 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3124,51 +3124,51 @@ Checking test 116 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 297.354528
-  0: The maximum resident set size (KB)                   = 533264
+  0: The total amount of wall time                        = 296.322149
+  0: The maximum resident set size (KB)                   = 530592
 
 Test 116 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/datm_cdeps_multiple_files_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/datm_cdeps_multiple_files_cfsr
 Checking test 117 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 140.611678
- 0: The maximum resident set size (KB)                   = 717484
+ 0: The total amount of wall time                        = 141.084156
+ 0: The maximum resident set size (KB)                   = 717988
 
 Test 117 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/datm_cdeps_3072x1536_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/datm_cdeps_3072x1536_cfsr
 Checking test 118 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 189.299901
- 0: The maximum resident set size (KB)                   = 1831364
+ 0: The total amount of wall time                        = 191.141668
+ 0: The maximum resident set size (KB)                   = 1830996
 
 Test 118 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/datm_cdeps_debug_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/datm_cdeps_debug_cfsr
 Checking test 119 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 431.648613
- 0: The maximum resident set size (KB)                   = 724764
+ 0: The total amount of wall time                        = 431.885415
+ 0: The maximum resident set size (KB)                   = 723568
 
 Test 119 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_atmwav
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_atmwav
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_atmwav
 Checking test 120 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3212,14 +3212,14 @@ Checking test 120 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 79.693038
-  0: The maximum resident set size (KB)                   = 495416
+  0: The total amount of wall time                        = 80.029840
+  0: The maximum resident set size (KB)                   = 491100
 
 Test 120 control_atmwav PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_c384gdas_wav
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_c384gdas_wav
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_c384gdas_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_c384gdas_wav
 Checking test 121 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3265,14 +3265,14 @@ Checking test 121 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 695.141876
-  0: The maximum resident set size (KB)                   = 1048740
+  0: The total amount of wall time                        = 699.682031
+  0: The maximum resident set size (KB)                   = 1047432
 
 Test 121 control_c384gdas_wav PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_atm_aerosols
-working dir  = /scratch1/BMC/gsd-fv3-dev/sun/hb_mar8b//stmp2/Shan.Sun/FV3_RT/rt_147329/control_atm_aerosols
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_atm_aerosols
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_82912/control_atm_aerosols
 Checking test 122 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3319,12 +3319,12 @@ Checking test 122 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 273.200953
-  0: The maximum resident set size (KB)                   = 889324
+  0: The total amount of wall time                        = 277.790951
+  0: The maximum resident set size (KB)                   = 898084
 
 Test 122 control_atm_aerosols PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Tue Mar  8 20:19:40 UTC 2022
-Elapsed time: 01h:05m:59s. Have a nice day!
+Wed Mar 23 21:00:23 UTC 2022
+Elapsed time: 01h:50m:18s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,23 +1,23 @@
-Wed Mar  9 16:09:12 GMT 2022
+Wed Mar 23 19:10:30 GMT 2022
 Start Regression test
 
-Compile 001 elapsed time 1657 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 222 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 1528 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 004 elapsed time 1504 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 005 elapsed time 1564 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 006 elapsed time 810 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
-Compile 007 elapsed time 210 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 008 elapsed time 228 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 208 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 1579 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 011 elapsed time 1583 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 012 elapsed time 278 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 001 elapsed time 1721 seconds. -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v16_coupled_p7_rrtmgp,FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 002 elapsed time 216 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1529 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v15_thompson_mynn_RRTMGP,FV3_GFS_v16_p7_rrtmgp,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 004 elapsed time 1520 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 005 elapsed time 1596 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 006 elapsed time 832 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DREPRO=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Bitforbit
+Compile 007 elapsed time 226 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_RRTMGP,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v16_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 008 elapsed time 224 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_flake,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 198 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 1573 seconds. -DAPP=HAFSW -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 011 elapsed time 1581 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 012 elapsed time 279 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
 Compile 013 elapsed time 125 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 014 elapsed time 1514 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 014 elapsed time 1508 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_control_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -82,14 +82,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 289.045195
-  0: The maximum resident set size (KB)                   = 594912
+  0: The total amount of wall time                        = 293.802556
+  0: The maximum resident set size (KB)                   = 597224
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_2threads_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -142,14 +142,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 896.673886
-  0: The maximum resident set size (KB)                   = 673124
+  0: The total amount of wall time                        = 905.859745
+  0: The maximum resident set size (KB)                   = 670316
 
 Test 002 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_mpi_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_mpi_p8
 Checking test 003 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -202,14 +202,14 @@ Checking test 003 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 251.010520
-  0: The maximum resident set size (KB)                   = 601688
+  0: The total amount of wall time                        = 261.225765
+  0: The maximum resident set size (KB)                   = 596868
 
 Test 003 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_p7_rrtmgp
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_control_p7_rrtmgp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_p7_rrtmgp
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_control_p7_rrtmgp
 Checking test 004 cpld_control_p7_rrtmgp results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -262,14 +262,14 @@ Checking test 004 cpld_control_p7_rrtmgp results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 335.399498
-  0: The maximum resident set size (KB)                   = 703948
+  0: The total amount of wall time                        = 338.276096
+  0: The maximum resident set size (KB)                   = 695060
 
 Test 004 cpld_control_p7_rrtmgp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_bmark_p7
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_bmark_p7
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_bmark_p7
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_bmark_p7
 Checking test 005 cpld_bmark_p7 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -314,14 +314,14 @@ Checking test 005 cpld_bmark_p7 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1158.714431
-  0: The maximum resident set size (KB)                   = 1371672
+  0: The total amount of wall time                        = 1257.538591
+  0: The maximum resident set size (KB)                   = 1362504
 
 Test 005 cpld_bmark_p7 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_bmark_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_bmark_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_bmark_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_bmark_p8
 Checking test 006 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -366,14 +366,14 @@ Checking test 006 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1157.276088
-  0: The maximum resident set size (KB)                   = 1370684
+  0: The total amount of wall time                        = 1192.144660
+  0: The maximum resident set size (KB)                   = 1364304
 
 Test 006 cpld_bmark_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_bmark_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_bmark_mpi_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_bmark_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_bmark_mpi_p8
 Checking test 007 cpld_bmark_mpi_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -418,14 +418,14 @@ Checking test 007 cpld_bmark_mpi_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1151.108873
-  0: The maximum resident set size (KB)                   = 1365000
+  0: The total amount of wall time                        = 1195.953292
+  0: The maximum resident set size (KB)                   = 1357244
 
 Test 007 cpld_bmark_mpi_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_c96_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_control_c96_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_c96_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_control_c96_p8
 Checking test 008 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -487,14 +487,14 @@ Checking test 008 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 281.367655
-  0: The maximum resident set size (KB)                   = 594696
+  0: The total amount of wall time                        = 286.331653
+  0: The maximum resident set size (KB)                   = 590404
 
 Test 008 cpld_control_c96_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_c96_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_restart_c96_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_c96_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_restart_c96_p8
 Checking test 009 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -544,14 +544,14 @@ Checking test 009 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 158.606342
-  0: The maximum resident set size (KB)                   = 353860
+  0: The total amount of wall time                        = 161.542734
+  0: The maximum resident set size (KB)                   = 353468
 
 Test 009 cpld_restart_c96_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_c192_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_control_c192_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_c192_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_control_c192_p8
 Checking test 010 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -601,14 +601,14 @@ Checking test 010 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 1199.014486
-  0: The maximum resident set size (KB)                   = 788496
+  0: The total amount of wall time                        = 1204.166859
+  0: The maximum resident set size (KB)                   = 787660
 
 Test 010 cpld_control_c192_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_c192_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_restart_c192_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_c192_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_restart_c192_p8
 Checking test 011 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -658,14 +658,14 @@ Checking test 011 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 748.376685
-  0: The maximum resident set size (KB)                   = 886628
+  0: The total amount of wall time                        = 754.550922
+  0: The maximum resident set size (KB)                   = 891188
 
 Test 011 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_c384_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_control_c384_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_c384_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_control_c384_p8
 Checking test 012 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -708,14 +708,14 @@ Checking test 012 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1337.749397
-  0: The maximum resident set size (KB)                   = 1341960
+  0: The total amount of wall time                        = 1337.926737
+  0: The maximum resident set size (KB)                   = 1346880
 
 Test 012 cpld_control_c384_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_control_c384_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_restart_c384_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_control_c384_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_restart_c384_p8
 Checking test 013 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -758,14 +758,14 @@ Checking test 013 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 723.993776
-  0: The maximum resident set size (KB)                   = 1300176
+  0: The total amount of wall time                        = 742.216726
+  0: The maximum resident set size (KB)                   = 1299844
 
 Test 013 cpld_restart_c384_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/cpld_debug_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/cpld_debug_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/cpld_debug_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/cpld_debug_p8
 Checking test 014 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -815,14 +815,14 @@ Checking test 014 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 804.733505
-  0: The maximum resident set size (KB)                   = 656996
+  0: The total amount of wall time                        = 800.689835
+  0: The maximum resident set size (KB)                   = 645792
 
 Test 014 cpld_debug_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control
 Checking test 015 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -869,14 +869,14 @@ Checking test 015 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 166.854695
-  0: The maximum resident set size (KB)                   = 476416
+  0: The total amount of wall time                        = 165.836252
+  0: The maximum resident set size (KB)                   = 477308
 
 Test 015 control PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_decomp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_decomp
 Checking test 016 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -919,28 +919,28 @@ Checking test 016 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 172.731605
-  0: The maximum resident set size (KB)                   = 476788
+  0: The total amount of wall time                        = 172.508987
+  0: The maximum resident set size (KB)                   = 476036
 
 Test 016 control_decomp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_2dwrtdecomp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_2dwrtdecomp
 Checking test 017 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 158.646674
-  0: The maximum resident set size (KB)                   = 481460
+  0: The total amount of wall time                        = 162.240188
+  0: The maximum resident set size (KB)                   = 479544
 
 Test 017 control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_2threads
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_2threads
 Checking test 018 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -983,14 +983,14 @@ Checking test 018 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 672.079357
- 0: The maximum resident set size (KB)                   = 528040
+ 0: The total amount of wall time                        = 641.677372
+ 0: The maximum resident set size (KB)                   = 524732
 
 Test 018 control_2threads PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_restart
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_restart
 Checking test 019 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1029,14 +1029,14 @@ Checking test 019 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 90.200488
-  0: The maximum resident set size (KB)                   = 214760
+  0: The total amount of wall time                        = 89.511567
+  0: The maximum resident set size (KB)                   = 214536
 
 Test 019 control_restart PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_fhzero
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_fhzero
 Checking test 020 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -1079,14 +1079,14 @@ Checking test 020 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 156.418145
-  0: The maximum resident set size (KB)                   = 476684
+  0: The total amount of wall time                        = 159.979407
+  0: The maximum resident set size (KB)                   = 474668
 
 Test 020 control_fhzero PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_CubedSphereGrid
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_CubedSphereGrid
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_CubedSphereGrid
 Checking test 021 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1113,14 +1113,14 @@ Checking test 021 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 158.885743
-  0: The maximum resident set size (KB)                   = 473304
+  0: The total amount of wall time                        = 159.024731
+  0: The maximum resident set size (KB)                   = 472084
 
 Test 021 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_latlon
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_latlon
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_latlon
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_latlon
 Checking test 022 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1131,17 +1131,17 @@ Checking test 022 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 162.486420
-  0: The maximum resident set size (KB)                   = 476372
+  0: The total amount of wall time                        = 162.384894
+  0: The maximum resident set size (KB)                   = 477376
 
 Test 022 control_latlon PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_wrtGauss_netcdf_parallel
 Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
- Comparing sfcf024.nc .........OK
+ Comparing sfcf024.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
  Comparing GFSFLX.GrbF00 .........OK
@@ -1149,14 +1149,14 @@ Checking test 023 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 164.515693
-  0: The maximum resident set size (KB)                   = 472888
+  0: The total amount of wall time                        = 167.448524
+  0: The maximum resident set size (KB)                   = 477740
 
 Test 023 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_c48
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_c48
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_c48
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_c48
 Checking test 024 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1195,14 +1195,14 @@ Checking test 024 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 536.047071
-0: The maximum resident set size (KB)                   = 662880
+0: The total amount of wall time                        = 532.712535
+0: The maximum resident set size (KB)                   = 663720
 
 Test 024 control_c48 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_c192
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_c192
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_c192
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_c192
 Checking test 025 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1213,14 +1213,14 @@ Checking test 025 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 642.862881
-  0: The maximum resident set size (KB)                   = 579736
+  0: The total amount of wall time                        = 648.826702
+  0: The maximum resident set size (KB)                   = 581624
 
 Test 025 control_c192 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_c384
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_c384
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_c384
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_c384
 Checking test 026 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1231,14 +1231,14 @@ Checking test 026 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 802.871148
-  0: The maximum resident set size (KB)                   = 747856
+  0: The total amount of wall time                        = 807.348476
+  0: The maximum resident set size (KB)                   = 751416
 
 Test 026 control_c384 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_c384gdas
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_c384gdas
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_c384gdas
 Checking test 027 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1281,14 +1281,14 @@ Checking test 027 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 739.707646
-  0: The maximum resident set size (KB)                   = 835712
+  0: The total amount of wall time                        = 740.791246
+  0: The maximum resident set size (KB)                   = 837396
 
 Test 027 control_c384gdas PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_stochy
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_stochy
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_stochy
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_stochy
 Checking test 028 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1299,28 +1299,28 @@ Checking test 028 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 109.191240
-  0: The maximum resident set size (KB)                   = 477184
+  0: The total amount of wall time                        = 110.711988
+  0: The maximum resident set size (KB)                   = 477740
 
 Test 028 control_stochy PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_stochy
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_stochy_restart
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_stochy
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_stochy_restart
 Checking test 029 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 61.196697
-  0: The maximum resident set size (KB)                   = 241008
+  0: The total amount of wall time                        = 62.478068
+  0: The maximum resident set size (KB)                   = 236740
 
 Test 029 control_stochy_restart PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_lndp
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_lndp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_lndp
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_lndp
 Checking test 030 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1331,14 +1331,14 @@ Checking test 030 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 97.797705
-  0: The maximum resident set size (KB)                   = 484812
+  0: The total amount of wall time                        = 99.957772
+  0: The maximum resident set size (KB)                   = 477212
 
 Test 030 control_lndp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_iovr4
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_iovr4
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_iovr4
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_iovr4
 Checking test 031 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1353,14 +1353,14 @@ Checking test 031 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 167.102097
-  0: The maximum resident set size (KB)                   = 471912
+  0: The total amount of wall time                        = 166.200709
+  0: The maximum resident set size (KB)                   = 479064
 
 Test 031 control_iovr4 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_iovr5
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_iovr5
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_iovr5
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_iovr5
 Checking test 032 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1375,14 +1375,14 @@ Checking test 032 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 165.322874
-  0: The maximum resident set size (KB)                   = 474004
+  0: The total amount of wall time                        = 166.415600
+  0: The maximum resident set size (KB)                   = 475440
 
 Test 032 control_iovr5 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_p8
 Checking test 033 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1429,14 +1429,14 @@ Checking test 033 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 185.893753
-  0: The maximum resident set size (KB)                   = 501816
+  0: The total amount of wall time                        = 189.137908
+  0: The maximum resident set size (KB)                   = 498356
 
 Test 033 control_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_restart_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_restart_p8
 Checking test 034 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1475,14 +1475,14 @@ Checking test 034 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 105.455446
-  0: The maximum resident set size (KB)                   = 290796
+  0: The total amount of wall time                        = 104.078187
+  0: The maximum resident set size (KB)                   = 289100
 
 Test 034 control_restart_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_decomp_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_decomp_p8
 Checking test 035 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1525,14 +1525,14 @@ Checking test 035 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 191.801487
-  0: The maximum resident set size (KB)                   = 496488
+  0: The total amount of wall time                        = 193.555549
+  0: The maximum resident set size (KB)                   = 496144
 
 Test 035 control_decomp_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_2threads_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_2threads_p8
 Checking test 036 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1575,14 +1575,14 @@ Checking test 036 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 693.257373
- 0: The maximum resident set size (KB)                   = 574196
+ 0: The total amount of wall time                        = 739.122368
+ 0: The maximum resident set size (KB)                   = 574268
 
 Test 036 control_2threads_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_p7_rrtmgp
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_p7_rrtmgp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_p7_rrtmgp
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_p7_rrtmgp
 Checking test 037 control_p7_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1629,14 +1629,14 @@ Checking test 037 control_p7_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 233.264841
-  0: The maximum resident set size (KB)                   = 601000
+  0: The total amount of wall time                        = 235.005190
+  0: The maximum resident set size (KB)                   = 594060
 
 Test 037 control_p7_rrtmgp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/regional_control
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/regional_control
 Checking test 038 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1647,42 +1647,42 @@ Checking test 038 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 413.185303
- 0: The maximum resident set size (KB)                   = 583584
+ 0: The total amount of wall time                        = 421.905442
+ 0: The maximum resident set size (KB)                   = 586628
 
 Test 038 regional_control PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/regional_restart
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/regional_restart
 Checking test 039 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 231.913174
- 0: The maximum resident set size (KB)                   = 580800
+ 0: The total amount of wall time                        = 229.206125
+ 0: The maximum resident set size (KB)                   = 581704
 
 Test 039 regional_restart PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_control
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/regional_control_2dwrtdecomp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/regional_control_2dwrtdecomp
 Checking test 040 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 413.274194
- 0: The maximum resident set size (KB)                   = 584352
+ 0: The total amount of wall time                        = 411.887108
+ 0: The maximum resident set size (KB)                   = 586040
 
 Test 040 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_noquilt
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/regional_noquilt
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_noquilt
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/regional_noquilt
 Checking test 041 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1690,14 +1690,14 @@ Checking test 041 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 439.019794
- 0: The maximum resident set size (KB)                   = 595576
+ 0: The total amount of wall time                        = 440.564944
+ 0: The maximum resident set size (KB)                   = 593364
 
 Test 041 regional_noquilt PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_hafs
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/regional_hafs
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_hafs
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/regional_hafs
 Checking test 042 regional_hafs results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1706,28 +1706,28 @@ Checking test 042 regional_hafs results ....
  Comparing HURPRS.GrbF00 .........OK
  Comparing HURPRS.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 406.871863
- 0: The maximum resident set size (KB)                   = 584888
+ 0: The total amount of wall time                        = 412.245925
+ 0: The maximum resident set size (KB)                   = 585388
 
 Test 042 regional_hafs PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_netcdf_parallel
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/regional_netcdf_parallel
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/regional_netcdf_parallel
 Checking test 043 regional_netcdf_parallel results ....
- Comparing dynf000.nc .........OK
- Comparing dynf024.nc .........OK
- Comparing phyf000.nc .........OK
- Comparing phyf024.nc .........OK
+ Comparing dynf000.nc ............ALT CHECK......OK
+ Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing phyf000.nc ............ALT CHECK......OK
+ Comparing phyf024.nc ............ALT CHECK......OK
 
- 0: The total amount of wall time                        = 407.391453
- 0: The maximum resident set size (KB)                   = 585908
+ 0: The total amount of wall time                        = 408.199339
+ 0: The maximum resident set size (KB)                   = 583584
 
 Test 043 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_RRTMGP
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/regional_RRTMGP
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_RRTMGP
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/regional_RRTMGP
 Checking test 044 regional_RRTMGP results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1738,14 +1738,14 @@ Checking test 044 regional_RRTMGP results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 515.586460
- 0: The maximum resident set size (KB)                   = 709760
+ 0: The total amount of wall time                        = 516.214097
+ 0: The maximum resident set size (KB)                   = 710460
 
 Test 044 regional_RRTMGP PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_control
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_control
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_control
 Checking test 045 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1792,14 +1792,14 @@ Checking test 045 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 463.856248
-  0: The maximum resident set size (KB)                   = 845680
+  0: The total amount of wall time                        = 465.428793
+  0: The maximum resident set size (KB)                   = 839012
 
 Test 045 rap_control PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/regional_spp_sppt_shum_skeb
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/regional_spp_sppt_shum_skeb
 Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1810,14 +1810,14 @@ Checking test 046 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 1253.578604
-  0: The maximum resident set size (KB)                   = 961256
+  0: The total amount of wall time                        = 1163.919437
+  0: The maximum resident set size (KB)                   = 961128
 
 Test 046 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_control
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_restart
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_restart
 Checking test 047 rap_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1856,14 +1856,14 @@ Checking test 047 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 238.318133
-  0: The maximum resident set size (KB)                   = 595080
+  0: The total amount of wall time                        = 241.235909
+  0: The maximum resident set size (KB)                   = 592708
 
 Test 047 rap_restart PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_sfcdiff
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_sfcdiff
 Checking test 048 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1910,14 +1910,14 @@ Checking test 048 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 461.415507
-  0: The maximum resident set size (KB)                   = 845960
+  0: The total amount of wall time                        = 470.356992
+  0: The maximum resident set size (KB)                   = 841964
 
 Test 048 rap_sfcdiff PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_sfcdiff
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_sfcdiff_restart
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_sfcdiff_restart
 Checking test 049 rap_sfcdiff_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1956,14 +1956,14 @@ Checking test 049 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 239.497234
-  0: The maximum resident set size (KB)                   = 593516
+  0: The total amount of wall time                        = 240.937263
+  0: The maximum resident set size (KB)                   = 591680
 
 Test 049 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hrrr_control
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/hrrr_control
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/hrrr_control
 Checking test 050 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2010,14 +2010,14 @@ Checking test 050 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 445.234986
-  0: The maximum resident set size (KB)                   = 841136
+  0: The total amount of wall time                        = 451.070187
+  0: The maximum resident set size (KB)                   = 835760
 
 Test 050 hrrr_control PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rrfs_v1beta
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rrfs_v1beta
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rrfs_v1beta
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rrfs_v1beta
 Checking test 051 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2064,14 +2064,14 @@ Checking test 051 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 463.020723
-  0: The maximum resident set size (KB)                   = 837460
+  0: The total amount of wall time                        = 459.343426
+  0: The maximum resident set size (KB)                   = 835152
 
 Test 051 rrfs_v1beta PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rrfs_conus13km_hrrr_warm
 Checking test 052 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2080,14 +2080,14 @@ Checking test 052 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 206.294654
-  0: The maximum resident set size (KB)                   = 691952
+  0: The total amount of wall time                        = 206.719264
+  0: The maximum resident set size (KB)                   = 689024
 
 Test 052 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rrfs_conus13km_radar_tten_warm
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rrfs_conus13km_radar_tten_warm
 Checking test 053 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2096,14 +2096,14 @@ Checking test 053 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 206.954261
-  0: The maximum resident set size (KB)                   = 696020
+  0: The total amount of wall time                        = 207.939257
+  0: The maximum resident set size (KB)                   = 691500
 
 Test 053 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_rrtmgp
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_rrtmgp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_rrtmgp
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_rrtmgp
 Checking test 054 control_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2114,14 +2114,14 @@ Checking test 054 control_rrtmgp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 250.110565
-  0: The maximum resident set size (KB)                   = 599788
+  0: The total amount of wall time                        = 253.734290
+  0: The maximum resident set size (KB)                   = 602244
 
 Test 054 control_rrtmgp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_rrtmgp_c192
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_rrtmgp_c192
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_rrtmgp_c192
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_rrtmgp_c192
 Checking test 055 control_rrtmgp_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -2132,14 +2132,14 @@ Checking test 055 control_rrtmgp_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 687.832748
-  0: The maximum resident set size (KB)                   = 806436
+  0: The total amount of wall time                        = 687.595575
+  0: The maximum resident set size (KB)                   = 804004
 
 Test 055 control_rrtmgp_c192 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_csawmg
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_csawmg
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_csawmg
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_csawmg
 Checking test 056 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2150,14 +2150,14 @@ Checking test 056 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 416.933096
-  0: The maximum resident set size (KB)                   = 538892
+  0: The total amount of wall time                        = 420.669316
+  0: The maximum resident set size (KB)                   = 535268
 
 Test 056 control_csawmg PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_csawmgt
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_csawmgt
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_csawmgt
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_csawmgt
 Checking test 057 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2168,14 +2168,14 @@ Checking test 057 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 412.560595
-  0: The maximum resident set size (KB)                   = 538896
+  0: The total amount of wall time                        = 414.845743
+  0: The maximum resident set size (KB)                   = 538284
 
 Test 057 control_csawmgt PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_flake
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_flake
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_flake
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_flake
 Checking test 058 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2186,14 +2186,14 @@ Checking test 058 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 276.937367
-  0: The maximum resident set size (KB)                   = 550288
+  0: The total amount of wall time                        = 281.207274
+  0: The maximum resident set size (KB)                   = 545404
 
 Test 058 control_flake PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_ras
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_ras
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_ras
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_ras
 Checking test 059 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2204,14 +2204,14 @@ Checking test 059 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 224.622091
-  0: The maximum resident set size (KB)                   = 507036
+  0: The total amount of wall time                        = 226.497977
+  0: The maximum resident set size (KB)                   = 511764
 
 Test 059 control_ras PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_thompson
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_thompson
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_thompson
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_thompson
 Checking test 060 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2222,14 +2222,14 @@ Checking test 060 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 278.865051
-  0: The maximum resident set size (KB)                   = 859092
+  0: The total amount of wall time                        = 280.933298
+  0: The maximum resident set size (KB)                   = 860116
 
 Test 060 control_thompson PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_thompson_no_aero
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_thompson_no_aero
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_thompson_no_aero
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_thompson_no_aero
 Checking test 061 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2240,54 +2240,54 @@ Checking test 061 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 267.747755
-  0: The maximum resident set size (KB)                   = 852952
+  0: The total amount of wall time                        = 267.655978
+  0: The maximum resident set size (KB)                   = 851516
 
 Test 061 control_thompson_no_aero PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_wam_repro
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_wam_repro
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_wam_repro
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_wam_repro
 Checking test 062 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 148.845457
-  0: The maximum resident set size (KB)                   = 238260
+  0: The total amount of wall time                        = 148.198601
+  0: The maximum resident set size (KB)                   = 238656
 
 Test 062 control_wam PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_debug
 Checking test 063 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 189.148930
-  0: The maximum resident set size (KB)                   = 541624
+  0: The total amount of wall time                        = 191.516819
+  0: The maximum resident set size (KB)                   = 544508
 
 Test 063 control_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_2threads_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_2threads_debug
 Checking test 064 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 363.635266
- 0: The maximum resident set size (KB)                   = 591824
+ 0: The total amount of wall time                        = 362.995849
+ 0: The maximum resident set size (KB)                   = 593036
 
 Test 064 control_2threads_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_CubedSphereGrid_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_CubedSphereGrid_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_CubedSphereGrid_debug
 Checking test 065 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2314,428 +2314,428 @@ Checking test 065 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 206.263413
-  0: The maximum resident set size (KB)                   = 543340
+  0: The total amount of wall time                        = 205.488664
+  0: The maximum resident set size (KB)                   = 546020
 
 Test 065 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_wrtGauss_netcdf_parallel_debug
 Checking test 066 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 192.304516
-  0: The maximum resident set size (KB)                   = 543216
+  0: The total amount of wall time                        = 195.648782
+  0: The maximum resident set size (KB)                   = 544576
 
 Test 066 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_stochy_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_stochy_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_stochy_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_stochy_debug
 Checking test 067 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 216.214587
-  0: The maximum resident set size (KB)                   = 551172
+  0: The total amount of wall time                        = 218.387952
+  0: The maximum resident set size (KB)                   = 546352
 
 Test 067 control_stochy_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_lndp_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_lndp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_lndp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_lndp_debug
 Checking test 068 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 194.093305
-  0: The maximum resident set size (KB)                   = 542548
+  0: The total amount of wall time                        = 193.511887
+  0: The maximum resident set size (KB)                   = 548528
 
 Test 068 control_lndp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_rrtmgp_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_rrtmgp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_rrtmgp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_rrtmgp_debug
 Checking test 069 control_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 209.814506
-  0: The maximum resident set size (KB)                   = 639248
+  0: The total amount of wall time                        = 210.695478
+  0: The maximum resident set size (KB)                   = 639600
 
 Test 069 control_rrtmgp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_csawmg_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_csawmg_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_csawmg_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_csawmg_debug
 Checking test 070 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 304.855513
-  0: The maximum resident set size (KB)                   = 576300
+  0: The total amount of wall time                        = 305.219786
+  0: The maximum resident set size (KB)                   = 577408
 
 Test 070 control_csawmg_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_csawmgt_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_csawmgt_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_csawmgt_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_csawmgt_debug
 Checking test 071 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 299.989534
-  0: The maximum resident set size (KB)                   = 578572
+  0: The total amount of wall time                        = 303.426059
+  0: The maximum resident set size (KB)                   = 576904
 
 Test 071 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_ras_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_ras_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_ras_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_ras_debug
 Checking test 072 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 195.699659
-  0: The maximum resident set size (KB)                   = 559960
+  0: The total amount of wall time                        = 195.420333
+  0: The maximum resident set size (KB)                   = 552892
 
 Test 072 control_ras_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_diag_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_diag_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_diag_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_diag_debug
 Checking test 073 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 201.139517
-  0: The maximum resident set size (KB)                   = 599668
+  0: The total amount of wall time                        = 202.024909
+  0: The maximum resident set size (KB)                   = 596440
 
 Test 073 control_diag_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_debug_p8
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_debug_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_debug_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_debug_p8
 Checking test 074 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 207.040923
-  0: The maximum resident set size (KB)                   = 566700
+  0: The total amount of wall time                        = 208.451466
+  0: The maximum resident set size (KB)                   = 567860
 
 Test 074 control_debug_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_thompson_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_thompson_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_thompson_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_thompson_debug
 Checking test 075 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 223.967813
-  0: The maximum resident set size (KB)                   = 902284
+  0: The total amount of wall time                        = 225.281039
+  0: The maximum resident set size (KB)                   = 896956
 
 Test 075 control_thompson_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_thompson_no_aero_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_thompson_no_aero_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_thompson_no_aero_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_thompson_no_aero_debug
 Checking test 076 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 214.678677
-  0: The maximum resident set size (KB)                   = 896556
+  0: The total amount of wall time                        = 215.073263
+  0: The maximum resident set size (KB)                   = 897876
 
 Test 076 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_thompson_debug_extdiag
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_thompson_extdiag_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_thompson_debug_extdiag
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_thompson_extdiag_debug
 Checking test 077 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 233.871011
-  0: The maximum resident set size (KB)                   = 930888
+  0: The total amount of wall time                        = 234.563918
+  0: The maximum resident set size (KB)                   = 931224
 
 Test 077 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_thompson_progcld_thompson_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_thompson_progcld_thompson_debug
 Checking test 078 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 221.644957
-  0: The maximum resident set size (KB)                   = 899332
+  0: The total amount of wall time                        = 225.965725
+  0: The maximum resident set size (KB)                   = 898708
 
 Test 078 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/fv3_regional_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/regional_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/fv3_regional_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/regional_debug
 Checking test 079 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 320.501675
- 0: The maximum resident set size (KB)                   = 607968
+ 0: The total amount of wall time                        = 324.823024
+ 0: The maximum resident set size (KB)                   = 607956
 
 Test 079 regional_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_control_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_control_debug
 Checking test 080 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 343.287067
-  0: The maximum resident set size (KB)                   = 914900
+  0: The total amount of wall time                        = 345.750795
+  0: The maximum resident set size (KB)                   = 912676
 
 Test 080 rap_control_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_control_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_unified_drag_suite_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_unified_drag_suite_debug
 Checking test 081 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.764654
-  0: The maximum resident set size (KB)                   = 911092
+  0: The total amount of wall time                        = 344.923355
+  0: The maximum resident set size (KB)                   = 910248
 
 Test 081 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_diag_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_diag_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_diag_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_diag_debug
 Checking test 082 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 364.743147
-  0: The maximum resident set size (KB)                   = 997360
+  0: The total amount of wall time                        = 366.219097
+  0: The maximum resident set size (KB)                   = 992752
 
 Test 082 rap_diag_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_cires_ugwp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_cires_ugwp_debug
 Checking test 083 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 350.679267
-  0: The maximum resident set size (KB)                   = 914064
+  0: The total amount of wall time                        = 352.907648
+  0: The maximum resident set size (KB)                   = 910168
 
 Test 083 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_cires_ugwp_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_unified_ugwp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_unified_ugwp_debug
 Checking test 084 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 349.750502
-  0: The maximum resident set size (KB)                   = 915324
+  0: The total amount of wall time                        = 351.346571
+  0: The maximum resident set size (KB)                   = 911424
 
 Test 084 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_noah_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_noah_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_noah_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_noah_debug
 Checking test 085 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 340.737899
-  0: The maximum resident set size (KB)                   = 911796
+  0: The total amount of wall time                        = 341.654514
+  0: The maximum resident set size (KB)                   = 910484
 
 Test 085 rap_noah_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_rrtmgp_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_rrtmgp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_rrtmgp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_rrtmgp_debug
 Checking test 086 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 585.966850
-  0: The maximum resident set size (KB)                   = 1009808
+  0: The total amount of wall time                        = 586.249900
+  0: The maximum resident set size (KB)                   = 1011604
 
 Test 086 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_lndp_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_lndp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_lndp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_lndp_debug
 Checking test 087 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 346.733940
-  0: The maximum resident set size (KB)                   = 910928
+  0: The total amount of wall time                        = 349.980873
+  0: The maximum resident set size (KB)                   = 912648
 
 Test 087 rap_lndp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_sfcdiff_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_sfcdiff_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_sfcdiff_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_sfcdiff_debug
 Checking test 088 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 345.134648
-  0: The maximum resident set size (KB)                   = 913452
+  0: The total amount of wall time                        = 345.744836
+  0: The maximum resident set size (KB)                   = 912740
 
 Test 088 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_flake_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_flake_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_flake_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_flake_debug
 Checking test 089 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 345.765797
-  0: The maximum resident set size (KB)                   = 913280
+  0: The total amount of wall time                        = 343.395124
+  0: The maximum resident set size (KB)                   = 912324
 
 Test 089 rap_flake_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 090 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 571.353984
-  0: The maximum resident set size (KB)                   = 916404
+  0: The total amount of wall time                        = 575.100759
+  0: The maximum resident set size (KB)                   = 906272
 
 Test 090 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rap_progcld_thompson_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rap_progcld_thompson_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rap_progcld_thompson_debug
 Checking test 091 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 344.353600
-  0: The maximum resident set size (KB)                   = 910380
+  0: The total amount of wall time                        = 349.280731
+  0: The maximum resident set size (KB)                   = 911264
 
 Test 091 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/rrfs_v1beta_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/rrfs_v1beta_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/rrfs_v1beta_debug
 Checking test 092 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 342.102149
-  0: The maximum resident set size (KB)                   = 906368
+  0: The total amount of wall time                        = 343.209330
+  0: The maximum resident set size (KB)                   = 907288
 
 Test 092 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_wam_debug
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_wam_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_wam_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_wam_debug
 Checking test 093 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 365.632557
-  0: The maximum resident set size (KB)                   = 264200
+  0: The total amount of wall time                        = 366.642482
+  0: The maximum resident set size (KB)                   = 265976
 
 Test 093 control_wam_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_atm
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/hafs_regional_atm
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_atm
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/hafs_regional_atm
 Checking test 094 hafs_regional_atm results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 1101.433558
-  0: The maximum resident set size (KB)                   = 791588
+  0: The total amount of wall time                        = 1083.530994
+  0: The maximum resident set size (KB)                   = 795100
 
 Test 094 hafs_regional_atm PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/hafs_regional_atm_thompson_gfdlsf
 Checking test 095 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 1176.726227
-  0: The maximum resident set size (KB)                   = 1150664
+  0: The total amount of wall time                        = 1163.377411
+  0: The maximum resident set size (KB)                   = 1157240
 
 Test 095 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_atm_ocn
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/hafs_regional_atm_ocn
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/hafs_regional_atm_ocn
 Checking test 096 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -2744,165 +2744,165 @@ Checking test 096 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 455.191339
-  0: The maximum resident set size (KB)                   = 817608
+  0: The total amount of wall time                        = 448.384209
+  0: The maximum resident set size (KB)                   = 815120
 
 Test 096 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_atm_wav
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/hafs_regional_atm_wav
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_atm_wav
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/hafs_regional_atm_wav
 Checking test 097 hafs_regional_atm_wav results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 918.636770
-  0: The maximum resident set size (KB)                   = 813776
+  0: The total amount of wall time                        = 920.901630
+  0: The maximum resident set size (KB)                   = 818396
 
 Test 097 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/hafs_regional_atm_ocn_wav
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/hafs_regional_atm_ocn_wav
 Checking test 098 hafs_regional_atm_ocn_wav results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 1024.379469
-  0: The maximum resident set size (KB)                   = 820648
+  0: The total amount of wall time                        = 1025.200737
+  0: The maximum resident set size (KB)                   = 818964
 
 Test 098 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_docn
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/hafs_regional_docn
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_docn
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/hafs_regional_docn
 Checking test 099 hafs_regional_docn results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 435.616945
-  0: The maximum resident set size (KB)                   = 820828
+  0: The total amount of wall time                        = 433.786119
+  0: The maximum resident set size (KB)                   = 822104
 
 Test 099 hafs_regional_docn PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_docn_oisst
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/hafs_regional_docn_oisst
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/hafs_regional_docn_oisst
 Checking test 100 hafs_regional_docn_oisst results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 444.098392
-  0: The maximum resident set size (KB)                   = 817884
+  0: The total amount of wall time                        = 433.512433
+  0: The maximum resident set size (KB)                   = 820676
 
 Test 100 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/hafs_regional_datm_cdeps
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/hafs_regional_datm_cdeps
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/hafs_regional_datm_cdeps
 Checking test 101 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1218.007751
-  0: The maximum resident set size (KB)                   = 857024
+  0: The total amount of wall time                        = 1221.025117
+  0: The maximum resident set size (KB)                   = 857504
 
 Test 101 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/datm_cdeps_control_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/datm_cdeps_control_cfsr
 Checking test 102 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 191.814557
- 0: The maximum resident set size (KB)                   = 726096
+ 0: The total amount of wall time                        = 195.243886
+ 0: The maximum resident set size (KB)                   = 724076
 
 Test 102 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/datm_cdeps_restart_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/datm_cdeps_restart_cfsr
 Checking test 103 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 114.730347
- 0: The maximum resident set size (KB)                   = 745984
+ 0: The total amount of wall time                        = 121.251050
+ 0: The maximum resident set size (KB)                   = 723324
 
 Test 103 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_control_gefs
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/datm_cdeps_control_gefs
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/datm_cdeps_control_gefs
 Checking test 104 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 190.277447
- 0: The maximum resident set size (KB)                   = 624440
+ 0: The total amount of wall time                        = 189.936095
+ 0: The maximum resident set size (KB)                   = 624800
 
 Test 104 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_stochy_gefs
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/datm_cdeps_stochy_gefs
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/datm_cdeps_stochy_gefs
 Checking test 105 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 192.826646
- 0: The maximum resident set size (KB)                   = 627876
+ 0: The total amount of wall time                        = 201.368344
+ 0: The maximum resident set size (KB)                   = 625836
 
 Test 105 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/datm_cdeps_bulk_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/datm_cdeps_bulk_cfsr
 Checking test 106 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 195.649806
- 0: The maximum resident set size (KB)                   = 726068
+ 0: The total amount of wall time                        = 211.910188
+ 0: The maximum resident set size (KB)                   = 746268
 
 Test 106 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_bulk_gefs
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/datm_cdeps_bulk_gefs
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/datm_cdeps_bulk_gefs
 Checking test 107 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 190.887709
- 0: The maximum resident set size (KB)                   = 623872
+ 0: The total amount of wall time                        = 197.056623
+ 0: The maximum resident set size (KB)                   = 623072
 
 Test 107 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/datm_cdeps_mx025_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/datm_cdeps_mx025_cfsr
 Checking test 108 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2911,14 +2911,14 @@ Checking test 108 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 408.667501
-  0: The maximum resident set size (KB)                   = 595352
+  0: The total amount of wall time                        = 414.699981
+  0: The maximum resident set size (KB)                   = 594208
 
 Test 108 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_mx025_gefs
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/datm_cdeps_mx025_gefs
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/datm_cdeps_mx025_gefs
 Checking test 109 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -2927,51 +2927,51 @@ Checking test 109 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 404.529259
-  0: The maximum resident set size (KB)                   = 562296
+  0: The total amount of wall time                        = 404.756664
+  0: The maximum resident set size (KB)                   = 565784
 
 Test 109 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_control_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/datm_cdeps_multiple_files_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/datm_cdeps_multiple_files_cfsr
 Checking test 110 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 194.538887
- 0: The maximum resident set size (KB)                   = 748232
+ 0: The total amount of wall time                        = 193.290761
+ 0: The maximum resident set size (KB)                   = 725872
 
 Test 110 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/datm_cdeps_3072x1536_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/datm_cdeps_3072x1536_cfsr
 Checking test 111 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 268.983205
- 0: The maximum resident set size (KB)                   = 1837380
+ 0: The total amount of wall time                        = 268.505761
+ 0: The maximum resident set size (KB)                   = 1835508
 
 Test 111 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/datm_cdeps_debug_cfsr
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/datm_cdeps_debug_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/datm_cdeps_debug_cfsr
 Checking test 112 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 568.625803
- 0: The maximum resident set size (KB)                   = 753932
+ 0: The total amount of wall time                        = 571.597008
+ 0: The maximum resident set size (KB)                   = 733792
 
 Test 112 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220304/INTEL/control_atmwav
-working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_266361/control_atmwav
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220323/INTEL/control_atmwav
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_39990/control_atmwav
 Checking test 113 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3015,12 +3015,12 @@ Checking test 113 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 109.623750
-  0: The maximum resident set size (KB)                   = 520008
+  0: The total amount of wall time                        = 112.416708
+  0: The maximum resident set size (KB)                   = 523520
 
 Test 113 control_atmwav PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Wed Mar  9 19:19:13 GMT 2022
-Elapsed time: 03h:10m:01s. Have a nice day!
+Thu Mar 24 16:40:00 GMT 2022
+Elapsed time: 21h:29m:30s. Have a nice day!

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -533,9 +533,10 @@ mkdir ${LOG_DIR}
 if [[ $ROCOTO == true ]]; then
 
   ROCOTO_XML=${PATHRT}/rocoto_workflow.xml
+  ROCOTO_STATE=${PATHRT}/rocoto_workflow.state
   ROCOTO_DB=${PATHRT}/rocoto_workflow.db
 
-  rm -f $ROCOTO_XML $ROCOTO_DB *_lock.db
+  rm -f $ROCOTO_XML $ROCOTO_DB $ROCOTO_STATE *_lock.db
 
   if [[ $MACHINE_ID = wcoss ]]; then
     QUEUE=dev
@@ -886,7 +887,7 @@ else
 
   rm -f fv3_*.x fv3_*.exe modules.fv3_* keep_tests.tmp
   [[ ${KEEP_RUNDIR} == false ]] && rm -rf ${RUNDIR_ROOT}
-  [[ ${ROCOTO} == true ]] && rm -f ${ROCOTO_XML} ${ROCOTO_DB} *_lock.db
+  [[ ${ROCOTO} == true ]] && rm -f ${ROCOTO_XML} ${ROCOTO_DB} ${ROCOTO_STATE} *_lock.db
   [[ ${TEST_35D} == true ]] && rm -f tests/cpld_bmark*_20*
   [[ ${SINGLE_NAME} != '' ]] && rm -f rt.conf.single
 fi

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -486,7 +486,7 @@ if [[ $TESTS_FILE =~ '35d' ]] || [[ $TESTS_FILE =~ 'weekly' ]]; then
   TEST_35D=true
 fi
 
-BL_DATE=20220304
+BL_DATE=20220323
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]] || [[ $MACHINE_ID = gaea.* ]] || [[ $MACHINE_ID = jet.* ]] || [[ $MACHINE_ID = s4.* ]]; then
   RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/gsl-develop-${BL_DATE}/${RT_COMPILER^^}}
 else

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -418,7 +418,7 @@ rocoto_create_compile_task() {
   fi
 
   cat << EOF >> $ROCOTO_XML
-  <task name="compile_${COMPILE_NR}" maxtries="3">
+  <task name="compile_${COMPILE_NR}" maxtries="${ROCOTO_COMPILE_MAXTRIES:-3}">
     $DEP_STRING
     <command>&PATHRT;/run_compile.sh &PATHRT; &RUNDIR_ROOT; "${MAKE_OPT}" ${COMPILE_NR}</command>
     <jobname>compile_${COMPILE_NR}</jobname>
@@ -455,7 +455,7 @@ rocoto_create_run_task() {
   fi
 
   cat << EOF >> $ROCOTO_XML
-    <task name="${TEST_NAME}${RT_SUFFIX}" maxtries="1">
+    <task name="${TEST_NAME}${RT_SUFFIX}" maxtries="${ROCOTO_TEST_MAXTRIES:-3}">
       <dependency> $DEP_STRING </dependency>
       <command>&PATHRT;/run_test.sh &PATHRT; &RUNDIR_ROOT; ${TEST_NAME} ${TEST_NR} ${COMPILE_NR} </command>
       <jobname>${TEST_NAME}${RT_SUFFIX}</jobname>
@@ -478,22 +478,44 @@ rocoto_kill() {
    done
 }
 
-rocoto_run() {
-
-  state="Active"
-  while [[ $state != "Done" ]]
-  do
+rocoto_step() {
+    # Run one iteration of rocotorun and rocotostat.
     $ROCOTORUN -v 10 -w $ROCOTO_XML -d $ROCOTO_DB
-    sleep 10
+    sleep 1
+    state="Active"
     state=$($ROCOTOSTAT -w $ROCOTO_XML -d $ROCOTO_DB -s | grep 197001010000 | awk -F" " '{print $2}')
     dead_compile=$($ROCOTOSTAT -w $ROCOTO_XML -d $ROCOTO_DB | grep compile_ | grep DEAD | head -1 | awk -F" " '{print $2}')
     if [[ ! -z ${dead_compile} ]]; then
       echo "y" | ${ROCOTOCOMPLETE} -w $ROCOTO_XML -d $ROCOTO_DB -m ${dead_compile}_tasks
       ${ROCOTOCOMPLETE} -w $ROCOTO_XML -d $ROCOTO_DB -t ${dead_compile}
     fi
-    sleep 20
-  done
+}
 
+rocoto_run() {
+  # Run the rocoto workflow until it is complete
+  local max_aborts=7
+  local naptime=20
+  local aborts=0
+  state="Active"
+  while [[ $state != "Done" ]]; do
+      # Run one iteration of rocotorun and rocotostat.  Use an
+      # exponential backoff algorithm to handle temporary system
+      # failures breaking rocotorun or rocotostat.
+      aborts=0
+      while ( ! rocoto_step ) && (( aborts<max_aborts )) ; do
+          aborts=$(( aborts+1 ))
+          sleep $(( naptime * 2**((aborts-1)%5) * RANDOM/32767 ))
+      done
+      if (( aborts>=max_aborts )) ; then
+          set +x
+          echo "The rocoto workflow commands aborted $max_aborts times."
+          echo "There may be something wrong with the $( hostname ) node or the batch system."
+          echo "I'm giving up. Sorry."
+          set -x
+          return 2
+      fi
+      sleep $naptime
+  done
 }
 
 

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -479,15 +479,18 @@ rocoto_kill() {
 }
 
 rocoto_step() {
+    set -e
+    echo "Unknown" > rocoto_workflow.state
     # Run one iteration of rocotorun and rocotostat.
     $ROCOTORUN -v 10 -w $ROCOTO_XML -d $ROCOTO_DB
     sleep 1
     #   Is it done?
     state=$($ROCOTOSTAT -w $ROCOTO_XML -d $ROCOTO_DB -s | grep 197001010000 | awk -F" " '{print $2}')
+    echo "$state" > $ROCOTO_STATE
     dead_compile=$($ROCOTOSTAT -w $ROCOTO_XML -d $ROCOTO_DB | grep compile_ | grep DEAD | head -1 | awk -F" " '{print $2}')
     if [[ ! -z ${dead_compile} ]]; then
-      echo "y" | ${ROCOTOCOMPLETE} -w $ROCOTO_XML -d $ROCOTO_DB -m ${dead_compile}_tasks
-      ${ROCOTOCOMPLETE} -w $ROCOTO_XML -d $ROCOTO_DB -t ${dead_compile}
+        echo "y" | ${ROCOTOCOMPLETE} -w $ROCOTO_XML -d $ROCOTO_DB -m ${dead_compile}_tasks
+        ${ROCOTOCOMPLETE} -w $ROCOTO_XML -d $ROCOTO_DB -t ${dead_compile}
     fi
 }
 
@@ -495,28 +498,36 @@ rocoto_run() {
   # Run the rocoto workflow until it is complete
   local naptime=60
   local step_attempts=0
-  local max_step_attempts=7
-   local result=0
+  local max_step_attempts=100 # infinite loop safeguard; should never reach this
+  local start_time=0
+  local now_time=0
+  local max_time=3600 # seconds to wait for Rocoto to start working again
+  local result=0
   state="Active"
   while [[ $state != "Done" ]]; do
       # Run one iteration of rocotorun and rocotostat.  Use an
       # exponential backoff algorithm to handle temporary system
-      # failures breaking rocotorun or rocotostat.
-      for step_attempts in $( seq 1 $max_step_attempts ) ; do
+      # failures breaking Rocoto.
+      start_time=$( env TZ=UTC date +%s )
+      for step_attempts in $( seq 1 "$max_step_attempts" ) ; do
+          now_time=$( env TZ=UTC date +%s )
+
           set +e
-          rocoto_step
+          ( rocoto_step )
           result=$?
+          state=$( cat $ROCOTO_STATE )
           set -e
-          if [[ "$state" == Done ]] ; then
+
+          if [[ "${state:-Unknown}" == Done ]] ; then
               set +x
               echo "Rocoto workflow has completed."
               set -x
               return 0
           elif [[ $result == 0 ]] ; then
               break # rocoto_step succeeded
-          elif (( step_attempts>=max_step_attempts )) ; then
+          elif (( now_time-start_time > max_time || step_attempts >= max_step_attempts )) ; then
               set +x
-              echo "The rocoto workflow commands aborted $step_attempts times."
+              echo "Rocoto commands have failed $step_attempts times, for $(( (now_time-start_time+30)/60 )) minutes."
               echo "There may be something wrong with the $( hostname ) node or the batch system."
               echo "I'm giving up. Sorry."
               set -x

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -482,7 +482,7 @@ rocoto_step() {
     # Run one iteration of rocotorun and rocotostat.
     $ROCOTORUN -v 10 -w $ROCOTO_XML -d $ROCOTO_DB
     sleep 1
-    state="Active"
+    #   Is it done?
     state=$($ROCOTOSTAT -w $ROCOTO_XML -d $ROCOTO_DB -s | grep 197001010000 | awk -F" " '{print $2}')
     dead_compile=$($ROCOTOSTAT -w $ROCOTO_XML -d $ROCOTO_DB | grep compile_ | grep DEAD | head -1 | awk -F" " '{print $2}')
     if [[ ! -z ${dead_compile} ]]; then
@@ -493,27 +493,37 @@ rocoto_step() {
 
 rocoto_run() {
   # Run the rocoto workflow until it is complete
-  local max_aborts=7
   local naptime=20
-  local aborts=0
+  local step_attempts=0
+  local max_step_attempts=10
+  local result=0
   state="Active"
   while [[ $state != "Done" ]]; do
       # Run one iteration of rocotorun and rocotostat.  Use an
       # exponential backoff algorithm to handle temporary system
       # failures breaking rocotorun or rocotostat.
-      aborts=0
-      while ( ! rocoto_step ) && (( aborts<max_aborts )) ; do
-          aborts=$(( aborts+1 ))
-          sleep $(( naptime * 2**((aborts-1)%5) * RANDOM/32767 ))
+      for step_attempts in $( seq 1 $max_step_attempts ) ; do
+          set +e
+          rocoto_step
+          result=$?
+          set -e
+          if [[ "$state" == Done ]] ; then
+              set +x
+              echo "Rocoto workflow has completed."
+              set -x
+              return 0
+          elif [[ $result == 0 ]] ; then
+              break # rocoto_step succeeded
+          elif (( step_attempts>=max_step_attempts )) ; then
+              set +x
+              echo "The rocoto workflow commands aborted $step_attempts times."
+              echo "There may be something wrong with the $( hostname ) node or the batch system."
+              echo "I'm giving up. Sorry."
+              set -x
+              return 2
+          fi
+          sleep $(( naptime * 2**((step_attempts-1)%5) * RANDOM/32767 ))
       done
-      if (( aborts>=max_aborts )) ; then
-          set +x
-          echo "The rocoto workflow commands aborted $max_aborts times."
-          echo "There may be something wrong with the $( hostname ) node or the batch system."
-          echo "I'm giving up. Sorry."
-          set -x
-          return 2
-      fi
       sleep $naptime
   done
 }

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -493,10 +493,10 @@ rocoto_step() {
 
 rocoto_run() {
   # Run the rocoto workflow until it is complete
-  local naptime=20
+  local naptime=60
   local step_attempts=0
-  local max_step_attempts=10
-  local result=0
+  local max_step_attempts=7
+   local result=0
   state="Active"
   while [[ $state != "Done" ]]; do
       # Run one iteration of rocotorun and rocotostat.  Use an
@@ -522,7 +522,7 @@ rocoto_run() {
               set -x
               return 2
           fi
-          sleep $(( naptime * 2**((step_attempts-1)%5) * RANDOM/32767 ))
+          sleep $(( naptime * 2**((step_attempts-1)%4) * RANDOM/32767 ))
       done
       sleep $naptime
   done


### PR DESCRIPTION
## Description

This PR includes a series of changes and code clean-ups. The primary impact is to improve the subgrid clouds in the MYNN-EDMF. The following modifications were made:

1. removed the first-order for of Chaboureau-Bechtold (CB) - now only uses q'2 version of CB
2. changed CB to use abs temperature instead of liquid temperature
3. Added 3d variable "sm3d" - stability function for momentum
4. revert to Tian-Kuang lateral entrainment - reduces high RH bias found in some HRRR cases
5. reduced entrainment rate for momentum
6. removed sections of code in RRTMG pre modules that added cloud fractions in precipitation.

The following modules were modified:

- ccpp/physics/physics/module_bl_mynn.F90
- ccpp/physics/physics/module_MYNNPBL_wrapper.F90
- ccpp/physics/physics/module_MYNNPBL_wrapper.meta
- ccpp/physics/physics/GFS_rrtmg_pre.F90
- ccpp/physics/physics/GFS_rrtmgp_gfdlmp_pre.F90
- ccpp/data/GFS_typdefs.F90
- ccpp/data/GFS_typdefs.meta


## Testing

How were these changes tested? case studies and retros
What compilers / HPCs was it tested with? intel/Hera
Are the changes covered by regression tests? not yet 
Have regression tests and unit tests (utests) been run? 
On which platforms and with which compilers? (Note that unit tests can only be run on tier-1 platforms)

- [ ] hera.intel
- [ ] hera.gnu
- [ ] orion.intel
- [ ] cheyenne.intel 
- [ ] cheyenne.gnu
- [ ] gaea.intel 
- [ ] jet.intel
- [ ] wcoss_cray
- [ ] wcoss_dell_p3
- [ ] opnReqTest for newly added/changed feature
- [ ] CI

## Dependencies

This PR is includes the PRs to the following submodules:
- waiting on https://github.com/NOAA-GSL/ccpp-physics/pull/141
- waiting on https://github.com/NOAA-GSL/fv3atm/pull/135
