### PR TITLE
Update to MYNN surface layer scheme

### DIFF
--- a/tests/default_vars.sh
+++ b/tests/default_vars.sh
@@ -839,6 +839,7 @@ export DO_MYNNEDMF=.false.
 export DO_MYJPBL=.false.
 export HURR_PBL=.false.
 export MONINQ_FAC=1.0
+export SFCLAY_COMPUTE_FLUX=.false.
 
 # Shallow/deep convection
 export DO_DEEP=.true.

--- a/tests/parm/rrfs_conus13km_hrrr.nml.IN
+++ b/tests/parm/rrfs_conus13km_hrrr.nml.IN
@@ -223,8 +223,6 @@
     lwhtr = .true.
     n_var_lndp = @[N_VAR_LNDP]
     nsradar_reset = 3600
-    nst_anl = .true.
-!    nstf_name = 2, 0, 0, 0, 0
     oz_phys = .false.
     oz_phys_2015 = .true.
     pdfcld = .false.

--- a/tests/parm/rrfs_conus13km_hrrr.nml.IN
+++ b/tests/parm/rrfs_conus13km_hrrr.nml.IN
@@ -133,6 +133,7 @@
 /
 
 &gfs_physics_nml
+    sfclay_compute_flux = @[SFCLAY_COMPUTE_FLUX]
     fh_dfi_radar = @[FH_DFI_RADAR]
     bl_mynn_edmf = 1
     bl_mynn_edmf_mom = 1
@@ -222,8 +223,8 @@
     lwhtr = .true.
     n_var_lndp = @[N_VAR_LNDP]
     nsradar_reset = 3600
-    nst_anl = .false.
-    nstf_name = 2, 0, 0, 0, 0
+    nst_anl = .true.
+!    nstf_name = 2, 0, 0, 0, 0
     oz_phys = .false.
     oz_phys_2015 = .true.
     pdfcld = .false.

--- a/tests/tests/rrfs_conus13km_hrrr_warm
+++ b/tests/tests/rrfs_conus13km_hrrr_warm
@@ -32,6 +32,7 @@ export OUTPUT_HISTORY=.true.
 export OUTPUT_GRID=lambert_conformal
 export OUTPUT_FILE="'netcdf'"
 
+export SFCLAY_COMPUTE_FLUX=.true.
 export IALB=2
 export ICLIQ_SW=2
 export IEMS=2

--- a/tests/tests/rrfs_conus13km_radar_tten_warm
+++ b/tests/tests/rrfs_conus13km_radar_tten_warm
@@ -34,6 +34,7 @@ export OUTPUT_HISTORY=.true.
 export OUTPUT_GRID=lambert_conformal
 export OUTPUT_FILE="'netcdf'"
 
+export SFCLAY_COMPUTE_FLUX=.true.
 export IALB=2
 export ICLIQ_SW=2
 export IEMS=2


### PR DESCRIPTION
## Description

1. Bug fix for COARE3.5 - this option is not used by default so it will not cause a change in results.
2. Bug fix for computing theta and rho at k=1 (was using p_sfc instead of p(k=1)).
3. Removed time averaging of u* over the water to be more similar to surface heat flux calculation in ocean_sfc.
4. Moved 4 internal parameters to namelist options:
- isftcflx (default = 0)
- iz0tlnd (default = 0)
- sfclay_compute_flux (default = .false. *which will change results of regression tests*)
- sfclay_compute_diag (default = .false.)

*Edit again by @SamuelTrahanNOAA* The regional_spp_sppt_shum_skeb fails in this PR, but that is not due to this PR's changes. The thompson scheme uses uninitialized memory when stochastic physics is enabled, and that's what regional_spp_sppt_shum_skeb tests. This PR changes totally unrelated portions of the code, but it is just enough to put nonphysical values in the uninitialized thompson scheme variables. PR https://github.com/ufs-community/ufs-weather-model/pull/1152 in the community repository should fix this.

## "To Do" List

- [ ] merge https://github.com/ufs-community/ufs-weather-model/pull/1152
- [ ] update regression tests for RRFS to use new namelist option `sfclay_compute_flux=.true.`
- [ ] hera.intel
- [ ] hera.gnu
- [ ] jet.intel
- [ ] merge https://github.com/NOAA-GSL/ccpp-physics/pull/143
- [ ] merge https://github.com/NOAA-GSL/fv3atm/pull/137
