### PR TITLE
adding regression test for HFIP test

### DIFF
--- a/tests/default_vars.sh
+++ b/tests/default_vars.sh
@@ -1186,7 +1186,7 @@ export USE_MERRA2=.true.
 export IAER=1011
 export NSTF_NAME=2,1,0,0,0
 
-export LHEATSTRG=.true.
+export LHEATSTRG=.false.
 export LSEASPRAY=.true.
 
 # P7 UGWP1

--- a/tests/parm/cpld_control_gf_mynn.nml.IN
+++ b/tests/parm/cpld_control_gf_mynn.nml.IN
@@ -1,0 +1,382 @@
+&atmos_model_nml
+  blocksize = 32
+  chksum_debug = .false.
+  dycore_only = .false.
+  ccpp_suite = '@[CCPP_SUITE]'
+/
+
+&diag_manager_nml
+  prepend_date = .false.
+  max_output_fields = @[MAX_OUTPUT_FIELDS]
+/
+
+&fms_io_nml
+  checksum_required = .false.
+  max_files_r = 100
+  max_files_w = 100
+/
+
+&mpp_io_nml
+shuffle=1
+deflate_level=1
+/
+
+&fms_nml
+  clock_grain = 'ROUTINE'
+  domains_stack_size = @[DOMAINS_STACK_SIZE]
+  print_memory_usage = .false.
+/
+
+&fv_core_nml
+  layout = @[INPES],@[JNPES]
+  io_layout = 1,1
+  npx = @[NPX]
+  npy = @[NPY]
+  ntiles = 6
+  npz = @[NPZ]
+  dz_min = @[DZ_MIN]
+  psm_bc = @[PSM_BC]
+  grid_type = -1
+  make_nh = @[MAKE_NH]
+  fv_debug = .false.
+  range_warn = .true.
+  reset_eta = .false.
+  n_sponge = 42
+  nudge_qv = .true.
+  nudge_dz = .false.
+  tau = 10.0
+  rf_cutoff = 7.5e2
+  d2_bg_k1 = @[D2_BG_K1]
+  d2_bg_k2 = @[D2_BG_K2]
+  kord_tm = -9
+  kord_mt = 9
+  kord_wz = 9
+  kord_tr = 9
+  hydrostatic = .false.
+  phys_hydrostatic = .false.
+  use_hydro_pressure = .false.
+  beta = 0.
+  a_imp = 1.
+  p_fac = 0.1
+  k_split = 2
+  n_split = 6
+  nwat = 6
+  na_init = @[NA_INIT]
+  d_ext = 0.
+  dnats = @[DNATS]
+  fv_sg_adj = 450
+  d2_bg = 0.
+  nord = 2
+  dddmp = @[DDDMP]
+  d4_bg = 0.12
+  vtdm4 = 0.02
+  delt_max = 0.002
+  ke_bg = 0.
+  do_vort_damp = .true.
+  external_ic = @[EXTERNAL_IC]
+  external_eta = .true.
+  gfs_phil = .false.
+  nggps_ic = @[NGGPS_IC]
+  mountain = @[MOUNTAIN]
+  ncep_ic = .false.
+  d_con = 1.
+  hord_mt = 5
+  hord_vt = 5
+  hord_tm = 5
+  hord_dp = -5
+  hord_tr = 8
+  adjust_dry_mass = .false.
+  dry_mass=98320.0
+  consv_te = 1.
+  do_sat_adj = @[DO_SAT_ADJ]
+  consv_am = .false.
+  fill = .true.
+  dwind_2d = .false.
+  print_freq = 6
+  warm_start = @[WARM_START]
+  no_dycore = .false.
+  z_tracer = .true.
+  agrid_vel_rst = .true.
+  read_increment = @[READ_INCREMENT]
+  res_latlon_dynamics = @[RES_LATLON_DYNAMICS]
+/
+
+&external_ic_nml
+  filtered_terrain = .true.
+  levp = @[NPZP]
+  gfs_dwinds = .true.
+  checker_tr = .false.
+  nt_checker = 0
+/
+
+&gfs_physics_nml
+  fhzero       = @[FHZERO]
+  h2o_phys     = .true.
+  ldiag3d      = @[LDIAG3D]
+  qdiag3d      = @[QDIAG3D]
+  print_diff_pgr = @[PRINT_DIFF_PGR]
+  fhcyc        = @[FHCYC]
+  use_ufo      = .true.
+  pre_rad      = .false.
+  imp_physics  = @[IMP_PHYSICS] 
+  iovr         = 3
+  ltaerosol    = .false.
+  lradar       = .false.
+  ttendlim     = -999
+  dt_inner     = @[DT_INNER]
+  sedi_semi    = @[SEDI_SEMI]
+  decfl        = @[DECFL]
+  oz_phys      = .false.
+  oz_phys_2015 = .true.
+  lsoil_lsm    = 4
+  do_mynnedmf  = .true.
+  do_mynnsfclay = .false.
+  icloud_bl    = 1
+  bl_mynn_edmf = 1
+  bl_mynn_tkeadvect = .true.
+  bl_mynn_edmf_mom = 1
+  do_ugwp      = .false.
+  do_tofd      = .false.
+  gwd_opt      = @[GWD_OPT]
+  do_ugwp_v0   = @[DO_UGWP_V0]
+  do_ugwp_v1   = @[DO_UGWP_V1]
+  do_ugwp_v0_orog_only = .false.
+  do_ugwp_v0_nst_only  = @[DO_UGWP_V0_NST_ONLY]
+  do_gsl_drag_ls_bl    = @[DO_GSL_DRAG_LS_BL]
+  do_gsl_drag_ss       = @[DO_GSL_DRAG_SS]
+  do_gsl_drag_tofd     = @[DO_GSL_DRAG_TOFD]
+  do_ugwp_v1_orog_only = @[DO_UGWP_V1_OROG_ONLY]
+  min_lakeice  = 0.15
+  min_seaice   = @[MIN_SEAICE]
+  use_cice_alb = @[USE_CICE_ALB]
+  pdfcld       = .false.
+  fhswr        = 3600.
+  fhlwr        = 3600.
+  ialb         = @[IALB]
+  iems         = @[IEMS]
+  iaer         = @[IAER]
+  icliq_sw     = 2
+  ico2         = 2
+  isubc_sw     = 2
+  isubc_lw     = 2
+  isol         = 2
+  lwhtr        = .true.
+  swhtr        = .true.
+  cnvgwd       = .true.
+  shal_cnv     = .false.
+  cal_pre      = .false.
+  redrag       = .true.
+  dspheat      = .true.
+  hybedmf      = .false.
+  satmedmf     = .false.
+  isatmedmf    = 1
+  lheatstrg    = @[LHEATSTRG]
+  lseaspray    = @[LSEASPRAY]
+  random_clds  = @[RANDOM_CLDS]
+  trans_trac   = .true.
+  cnvcld       = @[CNVCLD]
+  imfshalcnv   = -1
+  imfdeepcnv   = 3
+  ras          = @[RAS]
+  cdmbgwd      = @[CDMBWD]
+  prslrd0      = 0.
+  ivegsrc      = 1
+  isot         = 1
+  lsoil        = 4
+  lsm          = @[LSM]
+  iopt_dveg    = @[IOPT_DVEG]
+  iopt_crs     = @[IOPT_CRS]
+  iopt_btr     = 1
+  iopt_run     = 1
+  iopt_sfc     = @[IOPT_SFC]
+  iopt_trs     = @[IOPT_TRS]
+  iopt_frz     = 1
+  iopt_inf     = 1
+  iopt_rad     = @[IOPT_RAD]
+  iopt_alb     = @[IOPT_ALB]
+  iopt_snf     = 4
+  iopt_tbot    = 2
+  iopt_stc     = @[IOPT_STC]
+  debug        = .false.
+  nstf_name    = @[NSTF_NAME]
+  nst_anl      = .true.
+  psautco      = 0.0008,0.0005
+  prautco      = 0.00015,0.00015
+  lgfdlmprad   = @[LGFDLMPRAD]
+  effr_in      = .true.
+  ldiag_ugwp   = @[LDIAG_UGWP]
+  fscav_aero   = @[FSCAV_AERO]
+  do_sppt      = @[DO_SPPT]
+  do_shum      = @[DO_SHUM]
+  do_skeb      = @[DO_SKEB]
+  do_RRTMGP          = @[DO_RRTMGP]
+  active_gases       = 'h2o_co2_o3_n2o_ch4_o2'
+  ngases             = 6
+  lw_file_gas        = 'rrtmgp-data-lw-g128-210809.nc'
+  lw_file_clouds     = 'rrtmgp-cloud-optics-coeffs-lw.nc'
+  sw_file_gas        = 'rrtmgp-data-sw-g112-210809.nc'
+  sw_file_clouds     = 'rrtmgp-cloud-optics-coeffs-sw.nc'
+  rrtmgp_nGptsSW     = 112
+  rrtmgp_nGptsLW     = 128
+  rrtmgp_nBandsLW    = 16
+  rrtmgp_nBandsSW    = 14
+  doGP_cldoptics_LUT = @[DOGP_CLDOPTICS_LUT]
+  doGP_lwscat        = @[DOGP_LWSCAT]
+  frac_grid    = @[FRAC_GRID]
+  cplchm       = @[CPLCHM]
+  cplflx       = @[CPLFLX]
+  cplice       = @[CPLICE]
+  cplwav       = @[CPLWAV]
+  cplwav2atm   = @[CPLWAV2ATM]
+  do_ca        = @[DO_CA]
+  ca_global    = @[CA_GLOBAL]
+  ca_sgs       = @[CA_SGS]
+  nca          = @[NCA]
+  ncells       = @[NCELLS]
+  nlives       = @[NLIVES]
+  nseed        = @[NSEED]
+  nfracseed    = @[NFRACSEED]
+  nthresh      = @[NTHRESH]
+  ca_trigger   = @[CA_TRIGGER]
+  nspinup      = @[NSPINUP]
+  iseed_ca     = @[ISEED_CA]
+  lndp_type    = @[LNDP_TYPE]
+  n_var_lndp   = @[N_VAR_LNDP]
+/
+
+&cires_ugwp_nml
+  knob_ugwp_solver  = 2
+  knob_ugwp_source  = 1,1,0,0
+  knob_ugwp_wvspec  = 1,25,25,25
+  knob_ugwp_azdir   = 2,4,4,4
+  knob_ugwp_stoch   = 0,0,0,0
+  knob_ugwp_effac   = 1,1,1,1
+  knob_ugwp_doaxyz  = 1
+  knob_ugwp_doheat  = 1
+  knob_ugwp_dokdis  = 1
+  knob_ugwp_ndx4lh  = 1 
+  knob_ugwp_version = @[KNOB_UGWP_VERSION]
+  launch_level = 54
+/
+
+&gfdl_cloud_microphysics_nml
+  sedi_transport = .true.
+  do_sedi_heat = .false.
+  rad_snow = .true.
+  rad_graupel = .true.
+  rad_rain = .true.
+  const_vi = .false.
+  const_vs = .false.
+  const_vg = .false.
+  const_vr = .false.
+  vi_max = 1.
+  vs_max = 2.
+  vg_max = 12.
+  vr_max = 12.
+  qi_lim = 1.
+  prog_ccn = .false.
+  do_qa = .true.
+  fast_sat_adj = .true.
+  tau_l2v = 225.
+  tau_v2l = 150.
+  tau_g2v = 900.
+  rthresh = 10.e-6  ! This is a key parameter for cloud water
+  dw_land  = 0.16
+  dw_ocean = 0.10
+  ql_gen = 1.0e-3
+  ql_mlt = 1.0e-3
+  qi0_crt = 8.0E-5
+  qs0_crt = 1.0e-3
+  tau_i2s = 1000.
+  c_psaci = 0.05
+  c_pgacs = 0.01
+  rh_inc = 0.30
+  rh_inr = 0.30
+  rh_ins = 0.30
+  ccn_l = 300.
+  ccn_o = 100.
+  c_paut = 0.5
+  c_cracw = 0.8
+  use_ppm = .false.
+  use_ccn = .true.
+  mono_prof = .true.
+  z_slope_liq  = .true.
+  z_slope_ice  = .true.
+  de_ice = .false.
+  fix_negative = .true.
+  icloud_f = 1
+  mp_time = 150.
+  reiflag = 2
+/
+
+&interpolator_nml
+  interp_method = 'conserve_great_circle'
+/
+
+&namsfc
+  FNGLAC   = 'global_glacier.2x2.grb'
+  FNMXIC   = 'global_maxice.2x2.grb'
+  FNTSFC   = 'RTGSST.1982.2012.monthly.clim.grb'
+  FNSNOC   = 'global_snoclim.1.875.grb'
+  FNZORC   = 'igbp'
+  FNALBC   = @[FNALBC]
+  FNALBC2  = @[FNALBC2]
+  FNAISC   = 'CFSR.SEAICE.1982.2012.monthly.clim.grb'
+  FNTG3C   = @[FNTG3C]
+  FNVEGC   = @[FNVEGC]
+  FNVETC   = @[FNVETC]
+  FNSOTC   = @[FNSOTC]
+  FNSMCC   = @[FNSMCC]
+  FNMSKH   = @[FNMSKH]
+  FNTSFA   = ''
+  FNACNA   = ''
+  FNSNOA   = ''
+  FNVMNC   = @[FNVMNC]
+  FNVMXC   = @[FNVMXC]
+  FNSLPC   = @[FNSLPC]
+  FNABSC   = @[FNABSC]
+  LDEBUG   =.false.
+  FSMCL(2) = 99999
+  FSMCL(3) = 99999
+  FSMCL(4) = 99999
+  LANDICE  = @[LANDICE]
+  FTSFS    = 90
+  FAISL    = 99999
+  FAISS    = 99999
+  FSNOL    = 99999
+  FSNOS    = 99999
+  FSICL    = @[FSICL]
+  FSICS    = @[FSICS]
+  FTSFL    = 99999
+  FVETL    = 99999
+  FSOTL    = 99999
+  FvmnL    = 99999
+  FvmxL    = 99999
+  FSLPL    = 99999
+  FABSL    = 99999
+/
+
+&fv_grid_nml
+  grid_file = 'INPUT/grid_spec.nc'
+/
+
+&nam_stochy
+/
+
+&nam_sfcperts
+  lndp_type      = @[LNDP_TYPE]
+  lndp_model_type = @[LNDP_MODEL_TYPE]
+  LNDP_TAU=21600,
+  LNDP_LSCALE=500000,
+  ISEED_LNDP=2010,
+  lndp_var_list = @[LNDP_VAR_LIST]
+  lndp_prt_list = @[LNDP_PRT_LIST]
+/
+
+&MOM_input_nml
+  output_directory = 'MOM6_OUTPUT/',
+  input_filename = '@[MOM6_RESTART_SETTING]'
+  restart_input_dir = 'INPUT/',
+  restart_output_dir = 'RESTART/',
+  parameter_filename = 'INPUT/MOM_input',
+  'INPUT/MOM_override'/

--- a/tests/rt_hfip.conf
+++ b/tests/rt_hfip.conf
@@ -1,0 +1,13 @@
+###################################################################################################################################################################################
+# PROD tests                                                                                                                                                                      #
+###################################################################################################################################################################################
+
+COMPILE | -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v17_p8_gf,FV3_GFS_v17_p8_mynn,FV3_GFS_v17_p8_gf_mynn -D32BIT=ON |  | fv3 |
+
+RUN     | control_p8_gf_mynn_hfip          |                  | fv3 |
+RUN     | control_decomp_p8_gf_mynn_hfip   |                  |     |
+RUN     | control_2threads_p8_gf_mynn_hfip | - wcoss_cray     |     |
+RUN     | control_restart_p8_gf_mynn_hfip  |                  |     | control_p8_gf_mynn_hfip
+
+COMPILE | -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_p8_gf,FV3_GFS_v17_p8_mynn,FV3_GFS_v17_p8_gf_mynn |  | fv3 |
+RUN     | control_debug_p8_gf_mynn_hfip    |                  |     |

--- a/tests/tests/control_2threads_p8_gf_mynn_hfip
+++ b/tests/tests/control_2threads_p8_gf_mynn_hfip
@@ -1,0 +1,168 @@
+###############################################################################
+#
+#  Global control 2thread test GFSv16 atmosphere only at C96L127, P8 configuration
+#
+###############################################################################
+
+export TEST_DESCR="Compare global control with 2 threads results with control_p8_gf_mynn_hfip test"
+
+export CNTL_DIR=control_p8_gf_mynn_hfip
+
+export LIST_FILES="sfcf000.nc \
+                   sfcf024.nc \
+                   atmf000.nc \
+                   atmf024.nc \
+                   GFSFLX.GrbF00 \
+                   GFSFLX.GrbF24 \
+                   GFSPRS.GrbF00 \
+                   GFSPRS.GrbF24 \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc"
+
+export_fv3
+export NPZ=127
+export NPZP=128
+export DT_ATMOS=600
+export SYEAR=2021
+export SMONTH=03
+export SDAY=22
+export SHOUR=06
+export OUTPUT_GRID='gaussian_grid'
+export WRITE_DOPOST=.true.
+
+export THRD=2
+export TASKS=$TASKS_thrd
+export INPES=$INPES_thrd
+export JNPES=$JNPES_thrd
+export WRTTASK_PER_GROUP=6
+
+# P7 default
+export IALB=2
+export IEMS=2
+export LSM=2
+export IOPT_DVEG=4
+export IOPT_CRS=2
+export IOPT_RAD=3
+export IOPT_ALB=1
+export IOPT_STC=3
+# P8
+export IOPT_SFC=3
+export IOPT_TRS=2
+
+# FV3 P7 settings
+export D2_BG_K1=0.20
+export D2_BG_K2=0.04
+export PSM_BC=1
+# P8
+export DDDMP=0.1
+
+# P7 Merra2 Aerosols & NSST
+export USE_MERRA2=.true.
+export IAER=1011
+export NSTF_NAME=2,1,0,0,0
+
+export LHEATSTRG=.true.
+export LSEASPRAY=.true.
+
+# P7 UGWP1
+export GWD_OPT=2
+export DO_UGWP_V1=.false.
+export KNOB_UGWP_VERSION=0
+export KNOB_UGWP_NSLOPE=1
+export DO_UGWP_V0=.true.
+export DO_GSL_DRAG_LS_BL=.false.
+export DO_GSL_DRAG_SS=.true.
+export DO_GSL_DRAG_TOFD=.true.
+export DO_UGWP_V1_OROG_ONLY=.false.
+export DO_UGWP_V0_NST_ONLY=.false.
+export LDIAG_UGWP=.false.
+
+# P7 CA
+export DO_CA=.true.
+export CA_SGS=.true.
+export CA_GLOBAL=.false.
+export NCA=1
+export NCELLS=5
+export NLIVES=12
+export NTHRESH=18
+export NSEED=1
+export NFRACSEED=0.5
+export CA_TRIGGER=.true.
+export NSPINUP=1
+export ISEED_CA=12345
+
+# P7 settings
+export TILEDFIX=.true.
+export FNALBC="'C96.snowfree_albedo.tileX.nc'"
+export FNALBC2="'C96.facsf.tileX.nc'"
+export FNTG3C="'C96.substrate_temperature.tileX.nc'"
+export FNVEGC="'C96.vegetation_greenness.tileX.nc'"
+export FNVETC="'C96.vegetation_type.tileX.nc'"
+export FNSOTC="'C96.soil_type.tileX.nc'"
+export FNSMCC=${FNSMCC_control}
+export FNMSKH=${FNMSKH_control}
+export FNVMNC="'C96.vegetation_greenness.tileX.nc'"
+export FNVMXC="'C96.vegetation_greenness.tileX.nc'"
+export FNSLPC="'C96.slope_type.tileX.nc'"
+export FNABSC="'C96.maximum_snow_albedo.tileX.nc'"
+export LANDICE=".false."
+export FSICL=0
+export FSICS=0
+
+export IMP_PHYSICS=8
+export LGFDLMPRAD=.false.
+export DO_SAT_ADJ=.false.
+export DNATS=0
+export DZ_MIN=6
+
+#required for NML.IN sharing
+export MIN_SEAICE=0.15
+export FRAC_GRID=.true.
+export MOM6_RESTART_SETTING=n
+# P8 (not used for standalone)
+export USE_CICE_ALB=.false.
+
+export WRITE_NSFLIP=.true.
+
+export FV3_RUN=control_run.IN
+export CCPP_SUITE=FV3_GFS_v17_p8_gf_mynn
+export FIELD_TABLE=field_table_thompson_noaero_tke
+export DIAG_TABLE=diag_table_gfsv16_merra2
+# use same namelist for standalone,coupled P7
+export INPUT_NML=cpld_control_gf_mynn.nml.IN
+
+# P8 RRTMGP
+export DO_RRTMGP=.false.
+export DOGP_CLDOPTICS_LUT=.true.
+export DOGP_LWSCAT=.true.
+export DOGP_SGS_CNV=.true.

--- a/tests/tests/control_debug_p8_gf_mynn_hfip
+++ b/tests/tests/control_debug_p8_gf_mynn_hfip
@@ -1,0 +1,128 @@
+###############################################################################
+#
+#  Global control debug test: GFSv16 atmosphere only at C96L127, P8 configuration
+#
+###############################################################################
+
+export TEST_DESCR="Compare global control debug results with previous trunk version"
+
+export CNTL_DIR=control_debug_p8_gf_mynn_hfip
+
+export LIST_FILES="sfcf000.nc \
+                   sfcf001.nc \
+                   atmf000.nc \
+                   atmf001.nc"
+
+export_fv3
+export NPZ=127
+export NPZP=128
+export DT_ATMOS=600
+export SYEAR=2021
+export SMONTH=03
+export SDAY=22
+export SHOUR=06
+export OUTPUT_GRID='gaussian_grid'
+export FHMAX=1
+export OUTPUT_FH="0 1"
+#export WRITE_DOPOST=.true.
+
+# P7 default
+export IALB=2
+export IEMS=2
+export LSM=2
+export IOPT_DVEG=4
+export IOPT_CRS=2
+export IOPT_RAD=3
+export IOPT_ALB=1
+export IOPT_STC=3
+# P8
+export IOPT_SFC=3
+export IOPT_TRS=2
+
+# FV3 P7 settings
+export D2_BG_K1=0.20
+export D2_BG_K2=0.04
+export PSM_BC=1
+# P8
+export DDDMP=0.1
+
+# P7 Merra2 Aerosols & NSST
+export USE_MERRA2=.true.
+export IAER=1011
+export NSTF_NAME=2,1,0,0,0
+
+export LHEATSTRG=.true.
+export LSEASPRAY=.true.
+
+# P7 UGWP1
+export GWD_OPT=2
+export DO_UGWP_V1=.false.
+export KNOB_UGWP_VERSION=0
+export KNOB_UGWP_NSLOPE=1
+export DO_UGWP_V0=.true.
+export DO_GSL_DRAG_LS_BL=.false.
+export DO_GSL_DRAG_SS=.true.
+export DO_GSL_DRAG_TOFD=.true.
+export DO_UGWP_V1_OROG_ONLY=.false.
+export DO_UGWP_V0_NST_ONLY=.false.
+export LDIAG_UGWP=.false.
+
+# P7 CA
+export DO_CA=.true.
+export CA_SGS=.true.
+export CA_GLOBAL=.false.
+export NCA=1
+export NCELLS=5
+export NLIVES=12
+export NTHRESH=18
+export NSEED=1
+export NFRACSEED=0.5
+export CA_TRIGGER=.true.
+export NSPINUP=1
+export ISEED_CA=12345
+
+# P7 settings
+export TILEDFIX=.true.
+export FNALBC="'C96.snowfree_albedo.tileX.nc'"
+export FNALBC2="'C96.facsf.tileX.nc'"
+export FNTG3C="'C96.substrate_temperature.tileX.nc'"
+export FNVEGC="'C96.vegetation_greenness.tileX.nc'"
+export FNVETC="'C96.vegetation_type.tileX.nc'"
+export FNSOTC="'C96.soil_type.tileX.nc'"
+export FNSMCC=${FNSMCC_control}
+export FNMSKH=${FNMSKH_control}
+export FNVMNC="'C96.vegetation_greenness.tileX.nc'"
+export FNVMXC="'C96.vegetation_greenness.tileX.nc'"
+export FNSLPC="'C96.slope_type.tileX.nc'"
+export FNABSC="'C96.maximum_snow_albedo.tileX.nc'"
+export LANDICE=".false."
+export FSICL=0
+export FSICS=0
+
+export IMP_PHYSICS=8
+export LGFDLMPRAD=.false.
+export DO_SAT_ADJ=.false.
+export DNATS=0
+export DZ_MIN=6
+
+#required for NML.IN sharing
+export MIN_SEAICE=0.15
+export FRAC_GRID=.true.
+export MOM6_RESTART_SETTING=n
+# P8 (not used for standalone)
+export USE_CICE_ALB=.false.
+
+export WRITE_NSFLIP=.true.
+
+export FV3_RUN=control_run.IN
+export CCPP_SUITE=FV3_GFS_v17_p8_gf_mynn
+export FIELD_TABLE=field_table_thompson_noaero_tke
+export DIAG_TABLE=diag_table_gfsv16_merra2
+# use same namelist for standalone,coupled P7
+export INPUT_NML=cpld_control_gf_mynn.nml.IN
+
+# P8 RRTMGP
+export DO_RRTMGP=.false.
+export DOGP_CLDOPTICS_LUT=.true.
+export DOGP_LWSCAT=.true.
+export DOGP_SGS_CNV=.true.

--- a/tests/tests/control_decomp_p8_gf_mynn_hfip
+++ b/tests/tests/control_decomp_p8_gf_mynn_hfip
@@ -1,0 +1,167 @@
+###############################################################################
+#
+#  Global control domain decomp test with differrent PEs, C96L127, P8 configuration
+#
+###############################################################################
+
+export TEST_DESCR="Compare global decomp results with control_p8_gf_mynn_hfip test"
+
+export CNTL_DIR=control_p8_gf_mynn_hfip
+
+export LIST_FILES="sfcf000.nc \
+                   sfcf024.nc \
+                   atmf000.nc \
+                   atmf024.nc \
+                   GFSFLX.GrbF00 \
+                   GFSFLX.GrbF24 \
+                   GFSPRS.GrbF00 \
+                   GFSPRS.GrbF24 \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc"
+
+export_fv3
+export NPZ=127
+export NPZP=128
+export DT_ATMOS=600
+export SYEAR=2021
+export SMONTH=03
+export SDAY=22
+export SHOUR=06
+export RESTART_INTERVAL=0
+export OUTPUT_GRID='gaussian_grid'
+export WRITE_DOPOST=.true.
+export OUTPUT_FH='0 21 24'
+
+export INPES=6
+export JNPES=4
+
+# P7 default
+export IALB=2
+export IEMS=2
+export LSM=2
+export IOPT_DVEG=4
+export IOPT_CRS=2
+export IOPT_RAD=3
+export IOPT_ALB=1
+export IOPT_STC=3
+# P8
+export IOPT_SFC=3
+export IOPT_TRS=2
+
+# FV3 P7 settings
+export D2_BG_K1=0.20
+export D2_BG_K2=0.04
+export PSM_BC=1
+# P8
+export DDDMP=0.1
+
+# P7 Merra2 Aerosols & NSST
+export USE_MERRA2=.true.
+export IAER=1011
+export NSTF_NAME=2,1,0,0,0
+
+export LHEATSTRG=.true.
+export LSEASPRAY=.true.
+
+# P7 UGWP1
+export GWD_OPT=2
+export DO_UGWP_V1=.false.
+export KNOB_UGWP_VERSION=0
+export KNOB_UGWP_NSLOPE=1
+export DO_UGWP_V0=.true.
+export DO_GSL_DRAG_LS_BL=.false.
+export DO_GSL_DRAG_SS=.true.
+export DO_GSL_DRAG_TOFD=.true.
+export DO_UGWP_V1_OROG_ONLY=.false.
+export DO_UGWP_V0_NST_ONLY=.false.
+export LDIAG_UGWP=.false.
+
+# P7 CA
+export DO_CA=.true.
+export CA_SGS=.true.
+export CA_GLOBAL=.false.
+export NCA=1
+export NCELLS=5
+export NLIVES=12
+export NTHRESH=18
+export NSEED=1
+export NFRACSEED=0.5
+export CA_TRIGGER=.true.
+export NSPINUP=1
+export ISEED_CA=12345
+
+# P7 settings
+export TILEDFIX=.true.
+export FNALBC="'C96.snowfree_albedo.tileX.nc'"
+export FNALBC2="'C96.facsf.tileX.nc'"
+export FNTG3C="'C96.substrate_temperature.tileX.nc'"
+export FNVEGC="'C96.vegetation_greenness.tileX.nc'"
+export FNVETC="'C96.vegetation_type.tileX.nc'"
+export FNSOTC="'C96.soil_type.tileX.nc'"
+export FNSMCC=${FNSMCC_control}
+export FNMSKH=${FNMSKH_control}
+export FNVMNC="'C96.vegetation_greenness.tileX.nc'"
+export FNVMXC="'C96.vegetation_greenness.tileX.nc'"
+export FNSLPC="'C96.slope_type.tileX.nc'"
+export FNABSC="'C96.maximum_snow_albedo.tileX.nc'"
+export LANDICE=".false."
+export FSICL=0
+export FSICS=0
+
+export IMP_PHYSICS=8
+export LGFDLMPRAD=.false.
+export DO_SAT_ADJ=.false.
+export DNATS=0
+export DZ_MIN=6
+
+#required for NML.IN sharing
+export MIN_SEAICE=0.15
+export FRAC_GRID=.true.
+export MOM6_RESTART_SETTING=n
+# P8 (not used for standalone)
+export USE_CICE_ALB=.false.
+
+export WRITE_NSFLIP=.true.
+
+export FV3_RUN=control_run.IN
+export CCPP_SUITE=FV3_GFS_v17_p8_gf_mynn
+export FIELD_TABLE=field_table_thompson_noaero_tke
+export DIAG_TABLE=diag_table_gfsv16_merra2
+# use same namelist for standalone,coupled P7
+export INPUT_NML=cpld_control_gf_mynn.nml.IN
+
+# P8 RRTMGP
+export DO_RRTMGP=.false.
+export DOGP_CLDOPTICS_LUT=.true.
+export DOGP_LWSCAT=.true.
+export DOGP_SGS_CNV=.true.

--- a/tests/tests/control_p8_gf_mynn_hfip
+++ b/tests/tests/control_p8_gf_mynn_hfip
@@ -1,0 +1,168 @@
+###############################################################################
+#
+#  Global control test GFSv16 atmosphere only at C96L127, P8 configuration
+#
+###############################################################################
+
+export TEST_DESCR="Compare global control results with previous trunk version"
+
+export CNTL_DIR=control_p8_gf_mynn_hfip
+
+export LIST_FILES="sfcf000.nc \
+                   sfcf021.nc \
+                   sfcf024.nc \
+                   atmf000.nc \
+                   atmf021.nc \
+                   atmf024.nc \
+                   GFSFLX.GrbF00 \
+                   GFSFLX.GrbF21 \
+                   GFSFLX.GrbF24 \
+                   GFSPRS.GrbF00 \
+                   GFSPRS.GrbF21 \
+                   GFSPRS.GrbF24 \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc"
+
+export_fv3
+export NPZ=127
+export NPZP=128
+export DT_ATMOS=600
+export SYEAR=2021
+export SMONTH=03
+export SDAY=22
+export SHOUR=06
+export RESTART_INTERVAL="12 -1"
+export OUTPUT_GRID='gaussian_grid'
+export WRITE_DOPOST=.true.
+export OUTPUT_FH='0 21 24'
+
+# P7 default
+export IALB=2
+export IEMS=2
+export LSM=2
+export IOPT_DVEG=4
+export IOPT_CRS=2
+export IOPT_RAD=3
+export IOPT_ALB=1
+export IOPT_STC=3
+# P8
+export IOPT_SFC=3
+export IOPT_TRS=2
+
+# FV3 P7 settings
+export D2_BG_K1=0.20
+export D2_BG_K2=0.04
+export PSM_BC=1
+# P8
+export DDDMP=0.1
+
+# P7 Merra2 Aerosols & NSST
+export USE_MERRA2=.true.
+export IAER=1011
+export NSTF_NAME=2,1,0,0,0
+
+export LHEATSTRG=.true.
+export LSEASPRAY=.true.
+
+# P7 UGWP1
+export GWD_OPT=2
+export DO_UGWP_V1=.false.
+export KNOB_UGWP_VERSION=0
+export KNOB_UGWP_NSLOPE=1
+export DO_UGWP_V0=.true.
+export DO_GSL_DRAG_LS_BL=.false.
+export DO_GSL_DRAG_SS=.true.
+export DO_GSL_DRAG_TOFD=.true.
+export DO_UGWP_V1_OROG_ONLY=.false.
+export DO_UGWP_V0_NST_ONLY=.false.
+export LDIAG_UGWP=.false.
+
+# P7 CA
+export DO_CA=.true.
+export CA_SGS=.true.
+export CA_GLOBAL=.false.
+export NCA=1
+export NCELLS=5
+export NLIVES=12
+export NTHRESH=18
+export NSEED=1
+export NFRACSEED=0.5
+export CA_TRIGGER=.true.
+export NSPINUP=1
+export ISEED_CA=12345
+
+# P7 settings
+export TILEDFIX=.true.
+export FNALBC="'C96.snowfree_albedo.tileX.nc'"
+export FNALBC2="'C96.facsf.tileX.nc'"
+export FNTG3C="'C96.substrate_temperature.tileX.nc'"
+export FNVEGC="'C96.vegetation_greenness.tileX.nc'"
+export FNVETC="'C96.vegetation_type.tileX.nc'"
+export FNSOTC="'C96.soil_type.tileX.nc'"
+export FNSMCC=${FNSMCC_control}
+export FNMSKH=${FNMSKH_control}
+export FNVMNC="'C96.vegetation_greenness.tileX.nc'"
+export FNVMXC="'C96.vegetation_greenness.tileX.nc'"
+export FNSLPC="'C96.slope_type.tileX.nc'"
+export FNABSC="'C96.maximum_snow_albedo.tileX.nc'"
+export LANDICE=".false."
+export FSICL=0
+export FSICS=0
+
+export IMP_PHYSICS=8
+export LGFDLMPRAD=.false.
+export DO_SAT_ADJ=.false.
+export DNATS=0
+export DZ_MIN=6
+
+#required for NML.IN sharing
+export MIN_SEAICE=0.15
+export FRAC_GRID=.true.
+export MOM6_RESTART_SETTING=n
+# P8 (not used for standalone)
+export USE_CICE_ALB=.false.
+
+export WRITE_NSFLIP=.true.
+
+export FV3_RUN=control_run.IN
+export CCPP_SUITE=FV3_GFS_v17_p8_gf_mynn
+export FIELD_TABLE=field_table_thompson_noaero_tke
+export DIAG_TABLE=diag_table_gfsv16_merra2
+# use same namelist for standalone,coupled P7
+export INPUT_NML=cpld_control_gf_mynn.nml.IN
+
+# RRTMGP
+export DO_RRTMGP=.false.
+export DOGP_CLDOPTICS_LUT=.true.
+export DOGP_LWSCAT=.true.
+export DOGP_SGS_CNV=.true.

--- a/tests/tests/control_restart_p8_gf_mynn_hfip
+++ b/tests/tests/control_restart_p8_gf_mynn_hfip
@@ -1,0 +1,167 @@
+###############################################################################
+#
+#  Global control restart test GFSv16 atmosphere only at C96L127, P8 configuration
+#
+###############################################################################
+
+export TEST_DESCR="Compare global restart results with control_p8_gf_mynn_hfip test"
+
+export CNTL_DIR=control_p8_gf_mynn_hfip
+
+export LIST_FILES="sfcf024.nc \
+                   atmf024.nc \
+                   GFSFLX.GrbF24 \
+                   GFSPRS.GrbF24 \
+                   RESTART/coupler.res \
+                   RESTART/fv_core.res.nc \
+                   RESTART/fv_core.res.tile1.nc \
+                   RESTART/fv_core.res.tile2.nc \
+                   RESTART/fv_core.res.tile3.nc \
+                   RESTART/fv_core.res.tile4.nc \
+                   RESTART/fv_core.res.tile5.nc \
+                   RESTART/fv_core.res.tile6.nc \
+                   RESTART/fv_srf_wnd.res.tile1.nc \
+                   RESTART/fv_srf_wnd.res.tile2.nc \
+                   RESTART/fv_srf_wnd.res.tile3.nc \
+                   RESTART/fv_srf_wnd.res.tile4.nc \
+                   RESTART/fv_srf_wnd.res.tile5.nc \
+                   RESTART/fv_srf_wnd.res.tile6.nc \
+                   RESTART/fv_tracer.res.tile1.nc \
+                   RESTART/fv_tracer.res.tile2.nc \
+                   RESTART/fv_tracer.res.tile3.nc \
+                   RESTART/fv_tracer.res.tile4.nc \
+                   RESTART/fv_tracer.res.tile5.nc \
+                   RESTART/fv_tracer.res.tile6.nc \
+                   RESTART/phy_data.tile1.nc \
+                   RESTART/phy_data.tile2.nc \
+                   RESTART/phy_data.tile3.nc \
+                   RESTART/phy_data.tile4.nc \
+                   RESTART/phy_data.tile5.nc \
+                   RESTART/phy_data.tile6.nc \
+                   RESTART/sfc_data.tile1.nc \
+                   RESTART/sfc_data.tile2.nc \
+                   RESTART/sfc_data.tile3.nc \
+                   RESTART/sfc_data.tile4.nc \
+                   RESTART/sfc_data.tile5.nc \
+                   RESTART/sfc_data.tile6.nc"
+
+export_fv3
+export NPZ=127
+export NPZP=128
+export DT_ATMOS=600
+export SYEAR=2021
+export SMONTH=03
+export SDAY=22
+export SHOUR=06
+export OUTPUT_GRID='gaussian_grid'
+export WRITE_DOPOST=.true.
+export FHROT=12
+export RESTART_FILE_PREFIX="${SYEAR}${SMONTH}${SDAY}.$(printf "%02d" $(( ${SHOUR} + ${FHROT}  )))0000"
+
+export WARM_START=.true.
+export NGGPS_IC=.false.
+export EXTERNAL_IC=.false.
+export MAKE_NH=.false.
+export MOUNTAIN=.true.
+export NA_INIT=0
+
+# P7 default
+export IALB=2
+export IEMS=2
+export LSM=2
+export IOPT_DVEG=4
+export IOPT_CRS=2
+export IOPT_RAD=3
+export IOPT_ALB=1
+export IOPT_STC=3
+# P8
+export IOPT_SFC=3
+export IOPT_TRS=2
+
+# FV3 P7 settings
+export D2_BG_K1=0.20
+export D2_BG_K2=0.04
+export PSM_BC=1
+# P8
+export DDDMP=0.1
+
+# P7 Merra2 Aerosols & NSST
+export USE_MERRA2=.true.
+export IAER=1011
+export NSTF_NAME=2,0,0,0,0
+
+export LHEATSTRG=.true.
+export LSEASPRAY=.true.
+
+# P7 UGWP1
+export GWD_OPT=2
+export DO_UGWP_V1=.false.
+export KNOB_UGWP_VERSION=0
+export KNOB_UGWP_NSLOPE=1
+export DO_UGWP_V0=.true.
+export DO_GSL_DRAG_LS_BL=.false.
+export DO_GSL_DRAG_SS=.true.
+export DO_GSL_DRAG_TOFD=.true.
+export DO_UGWP_V1_OROG_ONLY=.false.
+export DO_UGWP_V0_NST_ONLY=.false.
+export LDIAG_UGWP=.false.
+
+# P7 CA
+export DO_CA=.true.
+export CA_SGS=.true.
+export CA_GLOBAL=.false.
+export NCA=1
+export NCELLS=5
+export NLIVES=12
+export NTHRESH=18
+export NSEED=1
+export NFRACSEED=0.5
+export CA_TRIGGER=.true.
+export NSPINUP=1
+export ISEED_CA=12345
+
+# P7 settings
+export TILEDFIX=.true.
+export FNALBC="'C96.snowfree_albedo.tileX.nc'"
+export FNALBC2="'C96.facsf.tileX.nc'"
+export FNTG3C="'C96.substrate_temperature.tileX.nc'"
+export FNVEGC="'C96.vegetation_greenness.tileX.nc'"
+export FNVETC="'C96.vegetation_type.tileX.nc'"
+export FNSOTC="'C96.soil_type.tileX.nc'"
+export FNSMCC=${FNSMCC_control}
+export FNMSKH=${FNMSKH_control}
+export FNVMNC="'C96.vegetation_greenness.tileX.nc'"
+export FNVMXC="'C96.vegetation_greenness.tileX.nc'"
+export FNSLPC="'C96.slope_type.tileX.nc'"
+export FNABSC="'C96.maximum_snow_albedo.tileX.nc'"
+export LANDICE=".false."
+export FSICL=0
+export FSICS=0
+
+export IMP_PHYSICS=8
+export LGFDLMPRAD=.false.
+export DO_SAT_ADJ=.false.
+export DNATS=0
+export DZ_MIN=6
+
+#required for NML.IN sharing
+export MIN_SEAICE=0.15
+export FRAC_GRID=.true.
+export MOM6_RESTART_SETTING=n
+# P8 (not used for standalone)
+export USE_CICE_ALB=.false.
+
+export WRITE_NSFLIP=.true.
+
+export FV3_RUN=control_run.IN
+export CCPP_SUITE=FV3_GFS_v17_p8_gf_mynn
+export FIELD_TABLE=field_table_thompson_noaero_tke
+export DIAG_TABLE=diag_table_gfsv16_merra2
+# use same namelist for standalone,coupled P7
+export INPUT_NML=cpld_control_gf_mynn.nml.IN
+
+# P8 RRTMGP
+export DO_RRTMGP=.false.
+export DOGP_CLDOPTICS_LUT=.true.
+export DOGP_LWSCAT=.true.
+export DOGP_SGS_CNV=.true.


### PR DESCRIPTION
This PR is to

    -- adding regression test 'rt_hfip.conf' for combined gf and mynn code test to be used in HFIP project;
    -- adding namelist 'cpld_control_gf_mynn.nml.IN', which has both gf and mynn turned on to be used in the regression test;
    -- adding 5 tests for default, decomp, 2threads, debug and restart tests, all passed;
    -- modifying LHEATSTRG from .true. to .false., in order not to double count (according to EMC weekly meeting 6/22/2022).

@joeolson42
