### PR TITLE
- Updates to GF and sgscloud_radpre for HFIP 2022

### DIFF
--- a/tests/RegressionTests_hera.gnu.log
+++ b/tests/RegressionTests_hera.gnu.log
@@ -1,17 +1,17 @@
-Fri Aug 12 17:56:02 UTC 2022
+Wed Aug 17 19:45:30 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 197 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 002 elapsed time 114 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 003 elapsed time 206 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_GFS_v17_p8_gf_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 307 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 107 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 006 elapsed time 233 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 007 elapsed time 129 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 008 elapsed time 113 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 001 elapsed time 185 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_flake,FV3_GFS_v16_thompson,FV3_GFS_v16_ras,FV3_GFS_v17_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 002 elapsed time 102 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 003 elapsed time 191 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_GFS_v17_p8_gf_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 294 seconds. -DAPP=ATM -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 95 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 006 elapsed time 215 seconds. -DAPP=S2S -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 007 elapsed time 118 seconds. -DAPP=S2S -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 008 elapsed time 107 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control
 Checking test 001 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -58,14 +58,14 @@ Checking test 001 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 771.682586
-  0: The maximum resident set size (KB)                   = 467076
+  0: The total amount of wall time                        = 789.189524
+  0: The maximum resident set size (KB)                   = 482584
 
 Test 001 control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_restart
 Checking test 002 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -104,14 +104,14 @@ Checking test 002 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 383.895536
-  0: The maximum resident set size (KB)                   = 171816
+  0: The total amount of wall time                        = 382.246933
+  0: The maximum resident set size (KB)                   = 186680
 
 Test 002 control_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_c48
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_c48
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_c48
 Checking test 003 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -150,14 +150,14 @@ Checking test 003 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 678.794714
-0: The maximum resident set size (KB)                   = 690448
+0: The total amount of wall time                        = 669.272099
+0: The maximum resident set size (KB)                   = 697096
 
 Test 003 control_c48 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_stochy
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_stochy
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_stochy
 Checking test 004 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -168,14 +168,14 @@ Checking test 004 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 636.289869
-  0: The maximum resident set size (KB)                   = 471992
+  0: The total amount of wall time                        = 628.576191
+  0: The maximum resident set size (KB)                   = 483248
 
 Test 004 control_stochy PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_flake
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_flake
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_flake
 Checking test 005 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -186,14 +186,14 @@ Checking test 005 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1385.248772
-  0: The maximum resident set size (KB)                   = 515324
+  0: The total amount of wall time                        = 1404.363892
+  0: The maximum resident set size (KB)                   = 529664
 
 Test 005 control_flake PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_thompson
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_thompson
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_thompson
 Checking test 006 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -204,14 +204,14 @@ Checking test 006 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 974.745116
-  0: The maximum resident set size (KB)                   = 835048
+  0: The total amount of wall time                        = 1002.526550
+  0: The maximum resident set size (KB)                   = 841360
 
 Test 006 control_thompson PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_thompson_no_aero
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_thompson_no_aero
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_thompson_no_aero
 Checking test 007 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -222,14 +222,14 @@ Checking test 007 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 1011.785181
-  0: The maximum resident set size (KB)                   = 823136
+  0: The total amount of wall time                        = 1026.839027
+  0: The maximum resident set size (KB)                   = 833880
 
 Test 007 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_ras
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_ras
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_ras
 Checking test 008 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -240,14 +240,14 @@ Checking test 008 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 850.863875
-  0: The maximum resident set size (KB)                   = 477592
+  0: The total amount of wall time                        = 854.035242
+  0: The maximum resident set size (KB)                   = 490808
 
 Test 008 control_ras PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_p8
 Checking test 009 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -294,28 +294,28 @@ Checking test 009 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 914.133893
-  0: The maximum resident set size (KB)                   = 819320
+  0: The total amount of wall time                        = 919.829997
+  0: The maximum resident set size (KB)                   = 836680
 
 Test 009 control_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/hrrr_control_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/hrrr_control_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/hrrr_control_debug
 Checking test 010 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.616461
-  0: The maximum resident set size (KB)                   = 815248
+  0: The total amount of wall time                        = 165.650705
+  0: The maximum resident set size (KB)                   = 838920
 
 Test 010 hrrr_control_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rap_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rap_control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rap_control
 Checking test 011 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -362,14 +362,14 @@ Checking test 011 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1391.994237
-  0: The maximum resident set size (KB)                   = 820416
+  0: The total amount of wall time                        = 1493.352157
+  0: The maximum resident set size (KB)                   = 832704
 
 Test 011 rap_control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rap_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rap_decomp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rap_decomp
 Checking test 012 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -416,14 +416,14 @@ Checking test 012 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1470.002227
-  0: The maximum resident set size (KB)                   = 822472
+  0: The total amount of wall time                        = 1565.559300
+  0: The maximum resident set size (KB)                   = 831848
 
 Test 012 rap_decomp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rap_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rap_2threads
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rap_2threads
 Checking test 013 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -470,14 +470,14 @@ Checking test 013 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1434.276256
- 0: The maximum resident set size (KB)                   = 886316
+ 0: The total amount of wall time                        = 1522.088257
+ 0: The maximum resident set size (KB)                   = 898084
 
 Test 013 rap_2threads PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rap_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rap_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rap_restart
 Checking test 014 rap_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -516,14 +516,14 @@ Checking test 014 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1012.457979
-  0: The maximum resident set size (KB)                   = 527288
+  0: The total amount of wall time                        = 1009.362176
+  0: The maximum resident set size (KB)                   = 546012
 
 Test 014 rap_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rap_sfcdiff
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rap_sfcdiff
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rap_sfcdiff
 Checking test 015 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -570,14 +570,14 @@ Checking test 015 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1401.478250
-  0: The maximum resident set size (KB)                   = 819908
+  0: The total amount of wall time                        = 1481.282489
+  0: The maximum resident set size (KB)                   = 832564
 
 Test 015 rap_sfcdiff PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rap_sfcdiff
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rap_sfcdiff_decomp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rap_sfcdiff_decomp
 Checking test 016 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -624,14 +624,14 @@ Checking test 016 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1482.040982
-  0: The maximum resident set size (KB)                   = 821576
+  0: The total amount of wall time                        = 1540.021388
+  0: The maximum resident set size (KB)                   = 833204
 
 Test 016 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rap_sfcdiff
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rap_sfcdiff_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rap_sfcdiff_restart
 Checking test 017 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -670,14 +670,14 @@ Checking test 017 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1049.048663
-  0: The maximum resident set size (KB)                   = 527776
+  0: The total amount of wall time                        = 1034.648815
+  0: The maximum resident set size (KB)                   = 542732
 
 Test 017 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/hrrr_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/hrrr_control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/hrrr_control
 Checking test 018 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -724,14 +724,14 @@ Checking test 018 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1401.175637
-  0: The maximum resident set size (KB)                   = 819456
+  0: The total amount of wall time                        = 1444.231808
+  0: The maximum resident set size (KB)                   = 829652
 
 Test 018 hrrr_control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/hrrr_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/hrrr_control_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/hrrr_control_restart
 Checking test 019 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -770,14 +770,14 @@ Checking test 019 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1004.519077
-  0: The maximum resident set size (KB)                   = 521360
+  0: The total amount of wall time                        = 972.019240
+  0: The maximum resident set size (KB)                   = 542720
 
 Test 019 hrrr_control_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/hrrr_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/hrrr_control_decomp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/hrrr_control_decomp
 Checking test 020 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -824,14 +824,14 @@ Checking test 020 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1405.946062
-  0: The maximum resident set size (KB)                   = 823992
+  0: The total amount of wall time                        = 1510.254953
+  0: The maximum resident set size (KB)                   = 830084
 
 Test 020 hrrr_control_decomp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/hrrr_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/hrrr_control_2threads
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/hrrr_control_2threads
 Checking test 021 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -878,14 +878,14 @@ Checking test 021 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1469.780888
- 0: The maximum resident set size (KB)                   = 877940
+ 0: The total amount of wall time                        = 1390.510517
+ 0: The maximum resident set size (KB)                   = 894364
 
 Test 021 hrrr_control_2threads PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rrfs_v1beta
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rrfs_v1beta
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rrfs_v1beta
 Checking test 022 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -932,14 +932,14 @@ Checking test 022 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1487.131482
-  0: The maximum resident set size (KB)                   = 820460
+  0: The total amount of wall time                        = 1474.889066
+  0: The maximum resident set size (KB)                   = 829336
 
 Test 022 rrfs_v1beta PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rrfs_conus13km_hrrr_warm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rrfs_conus13km_hrrr_warm
 Checking test 023 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -948,14 +948,14 @@ Checking test 023 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1493.011198
-  0: The maximum resident set size (KB)                   = 624872
+  0: The total amount of wall time                        = 1525.415140
+  0: The maximum resident set size (KB)                   = 640420
 
 Test 023 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rrfs_conus13km_radar_tten_warm
 Checking test 024 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -964,14 +964,14 @@ Checking test 024 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1510.670258
-  0: The maximum resident set size (KB)                   = 626776
+  0: The total amount of wall time                        = 1496.433807
+  0: The maximum resident set size (KB)                   = 639872
 
 Test 024 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rrfs_smoke_conus13km_hrrr_warm
 Checking test 025 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -980,14 +980,14 @@ Checking test 025 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 1598.609855
-  0: The maximum resident set size (KB)                   = 635724
+  0: The total amount of wall time                        = 1529.639245
+  0: The maximum resident set size (KB)                   = 654324
 
 Test 025 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_p8_gf_mynn_hfip
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_p8_gf_mynn_hfip
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_p8_gf_mynn_hfip
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_p8_gf_mynn_hfip
 Checking test 026 control_p8_gf_mynn_hfip results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1034,14 +1034,14 @@ Checking test 026 control_p8_gf_mynn_hfip results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1066.738271
-  0: The maximum resident set size (KB)                   = 818892
+  0: The total amount of wall time                        = 1067.942140
+  0: The maximum resident set size (KB)                   = 829124
 
 Test 026 control_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_p8_gf_mynn_hfip
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_decomp_p8_gf_mynn_hfip
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_p8_gf_mynn_hfip
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_decomp_p8_gf_mynn_hfip
 Checking test 027 control_decomp_p8_gf_mynn_hfip results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1084,14 +1084,14 @@ Checking test 027 control_decomp_p8_gf_mynn_hfip results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1186.312094
-  0: The maximum resident set size (KB)                   = 809404
+  0: The total amount of wall time                        = 1152.696149
+  0: The maximum resident set size (KB)                   = 826052
 
 Test 027 control_decomp_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_p8_gf_mynn_hfip
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_2threads_p8_gf_mynn_hfip
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_p8_gf_mynn_hfip
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_2threads_p8_gf_mynn_hfip
 Checking test 028 control_2threads_p8_gf_mynn_hfip results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1134,14 +1134,14 @@ Checking test 028 control_2threads_p8_gf_mynn_hfip results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1152.886723
- 0: The maximum resident set size (KB)                   = 890980
+ 0: The total amount of wall time                        = 1131.470403
+ 0: The maximum resident set size (KB)                   = 905052
 
 Test 028 control_2threads_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_p8_gf_mynn_hfip
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_restart_p8_gf_mynn_hfip
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_p8_gf_mynn_hfip
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_restart_p8_gf_mynn_hfip
 Checking test 029 control_restart_p8_gf_mynn_hfip results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1180,250 +1180,250 @@ Checking test 029 control_restart_p8_gf_mynn_hfip results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 534.252748
-  0: The maximum resident set size (KB)                   = 547924
+  0: The total amount of wall time                        = 540.307199
+  0: The maximum resident set size (KB)                   = 563372
 
 Test 029 control_restart_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_debug
 Checking test 030 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 99.121695
-  0: The maximum resident set size (KB)                   = 449776
+  0: The total amount of wall time                        = 97.274207
+  0: The maximum resident set size (KB)                   = 476892
 
 Test 030 control_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_diag_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_diag_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_diag_debug
 Checking test 031 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 123.829756
-  0: The maximum resident set size (KB)                   = 513896
+  0: The total amount of wall time                        = 120.328933
+  0: The maximum resident set size (KB)                   = 534792
 
 Test 031 control_diag_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/fv3_regional_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/regional_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/regional_debug
 Checking test 032 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 127.735452
- 0: The maximum resident set size (KB)                   = 526716
+ 0: The total amount of wall time                        = 125.807222
+ 0: The maximum resident set size (KB)                   = 552100
 
 Test 032 regional_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rap_control_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rap_control_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rap_control_debug
 Checking test 033 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 166.163804
-  0: The maximum resident set size (KB)                   = 821116
+  0: The total amount of wall time                        = 165.848882
+  0: The maximum resident set size (KB)                   = 843040
 
 Test 033 rap_control_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rap_diag_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rap_diag_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rap_diag_debug
 Checking test 034 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 207.044200
-  0: The maximum resident set size (KB)                   = 908372
+  0: The total amount of wall time                        = 203.741701
+  0: The maximum resident set size (KB)                   = 927516
 
 Test 034 rap_diag_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 035 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 268.941465
-  0: The maximum resident set size (KB)                   = 822232
+  0: The total amount of wall time                        = 264.796289
+  0: The maximum resident set size (KB)                   = 845416
 
 Test 035 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rap_progcld_thompson_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rap_progcld_thompson_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rap_progcld_thompson_debug
 Checking test 036 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.115960
-  0: The maximum resident set size (KB)                   = 826636
+  0: The total amount of wall time                        = 164.343174
+  0: The maximum resident set size (KB)                   = 846028
 
 Test 036 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/rrfs_v1beta_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/rrfs_v1beta_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/rrfs_v1beta_debug
 Checking test 037 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.252512
-  0: The maximum resident set size (KB)                   = 819828
+  0: The total amount of wall time                        = 166.614726
+  0: The maximum resident set size (KB)                   = 839704
 
 Test 037 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_thompson_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_thompson_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_thompson_debug
 Checking test 038 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 117.444390
-  0: The maximum resident set size (KB)                   = 820460
+  0: The total amount of wall time                        = 111.038113
+  0: The maximum resident set size (KB)                   = 838460
 
 Test 038 control_thompson_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_thompson_no_aero_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_thompson_no_aero_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_thompson_no_aero_debug
 Checking test 039 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 113.292027
-  0: The maximum resident set size (KB)                   = 814396
+  0: The total amount of wall time                        = 109.616591
+  0: The maximum resident set size (KB)                   = 829592
 
 Test 039 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_thompson_debug_extdiag
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_thompson_extdiag_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_thompson_extdiag_debug
 Checking test 040 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 132.873439
-  0: The maximum resident set size (KB)                   = 844924
+  0: The total amount of wall time                        = 133.302745
+  0: The maximum resident set size (KB)                   = 868072
 
 Test 040 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_thompson_progcld_thompson_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_thompson_progcld_thompson_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_thompson_progcld_thompson_debug
 Checking test 041 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 114.233619
-  0: The maximum resident set size (KB)                   = 816556
+  0: The total amount of wall time                        = 113.728083
+  0: The maximum resident set size (KB)                   = 834360
 
 Test 041 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_ras_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_ras_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_ras_debug
 Checking test 042 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 104.741855
-  0: The maximum resident set size (KB)                   = 463748
+  0: The total amount of wall time                        = 99.728743
+  0: The maximum resident set size (KB)                   = 490636
 
 Test 042 control_ras_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_stochy_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_stochy_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_stochy_debug
 Checking test 043 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 115.793873
-  0: The maximum resident set size (KB)                   = 461044
+  0: The total amount of wall time                        = 113.723273
+  0: The maximum resident set size (KB)                   = 480252
 
 Test 043 control_stochy_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_debug_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_debug_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_debug_p8
 Checking test 044 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 112.026947
-  0: The maximum resident set size (KB)                   = 813552
+  0: The total amount of wall time                        = 111.718512
+  0: The maximum resident set size (KB)                   = 830900
 
 Test 044 control_debug_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_debug_p8_gf_mynn_hfip
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_debug_p8_gf_mynn_hfip
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_debug_p8_gf_mynn_hfip
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_debug_p8_gf_mynn_hfip
 Checking test 045 control_debug_p8_gf_mynn_hfip results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 152.507219
-  0: The maximum resident set size (KB)                   = 819396
+  0: The total amount of wall time                        = 151.855362
+  0: The maximum resident set size (KB)                   = 837340
 
 Test 045 control_debug_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/control_wam_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/control_wam_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/control_wam_debug
 Checking test 046 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 184.017609
-  0: The maximum resident set size (KB)                   = 166560
+  0: The total amount of wall time                        = 187.036637
+  0: The maximum resident set size (KB)                   = 193764
 
 Test 046 control_wam_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/cpld_control_c96_noaero_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/cpld_control_c96_noaero_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/cpld_control_c96_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/cpld_control_c96_noaero_p8
 Checking test 047 cpld_control_c96_noaero_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -1485,14 +1485,14 @@ Checking test 047 cpld_control_c96_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1118.189872
-  0: The maximum resident set size (KB)                   = 846788
+  0: The total amount of wall time                        = 1112.210102
+  0: The maximum resident set size (KB)                   = 862648
 
 Test 047 cpld_control_c96_noaero_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/cpld_debug_noaero_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/cpld_debug_noaero_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/cpld_debug_noaero_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/cpld_debug_noaero_p8
 Checking test 048 cpld_debug_noaero_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -1542,25 +1542,25 @@ Checking test 048 cpld_debug_noaero_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 597.644340
-  0: The maximum resident set size (KB)                   = 848812
+  0: The total amount of wall time                        = 570.900554
+  0: The maximum resident set size (KB)                   = 871668
 
 Test 048 cpld_debug_noaero_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220808/GNU/datm_cdeps_control_cfsr
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_49673/datm_cdeps_control_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/GNU/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_14158/datm_cdeps_control_cfsr
 Checking test 049 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 163.094214
- 0: The maximum resident set size (KB)                   = 623672
+ 0: The total amount of wall time                        = 166.036169
+ 0: The maximum resident set size (KB)                   = 627368
 
 Test 049 datm_cdeps_control_cfsr PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Aug 12 18:51:46 UTC 2022
-Elapsed time: 00h:55m:44s. Have a nice day!
+Wed Aug 17 20:42:59 UTC 2022
+Elapsed time: 00h:57m:29s. Have a nice day!

--- a/tests/RegressionTests_hera.intel.log
+++ b/tests/RegressionTests_hera.intel.log
@@ -1,26 +1,26 @@
-Tue Aug  9 04:31:33 UTC 2022
+Wed Aug 17 20:44:19 UTC 2022
 Start Regression test
 
-Compile 001 elapsed time 559 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 002 elapsed time 267 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 315 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 004 elapsed time 224 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 560 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl,FV3_GFS_v17_p8_gf_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 006 elapsed time 329 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 007 elapsed time 316 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 008 elapsed time 213 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 492 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake,FV3_GFS_v17_p8_gf_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 192 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 435 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 552 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 013 elapsed time 742 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 014 elapsed time 515 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
-Compile 015 elapsed time 162 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 016 elapsed time 506 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
-Compile 017 elapsed time 443 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 001 elapsed time 557 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 002 elapsed time 555 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 666 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 004 elapsed time 193 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 681 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl,FV3_GFS_v17_p8_gf_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 006 elapsed time 358 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 007 elapsed time 309 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 008 elapsed time 326 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 369 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake,FV3_GFS_v17_p8_gf_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 191 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 210 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 528 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 013 elapsed time 856 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 014 elapsed time 184 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DMOM6SOLO=ON
+Compile 015 elapsed time 307 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 016 elapsed time 728 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release
+Compile 017 elapsed time 329 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/cpld_control_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/cpld_control_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -86,14 +86,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 352.537561
-  0: The maximum resident set size (KB)                   = 1110900
+  0: The total amount of wall time                        = 354.821257
+  0: The maximum resident set size (KB)                   = 1132368
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/cpld_control_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/cpld_2threads_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -147,14 +147,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 435.780799
-  0: The maximum resident set size (KB)                   = 1686568
+  0: The total amount of wall time                        = 436.902092
+  0: The maximum resident set size (KB)                   = 1710232
 
 Test 002 cpld_2threads_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/cpld_control_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/cpld_decomp_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/cpld_decomp_p8
 Checking test 003 cpld_decomp_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -208,14 +208,14 @@ Checking test 003 cpld_decomp_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 353.377852
-  0: The maximum resident set size (KB)                   = 1095772
+  0: The total amount of wall time                        = 352.932950
+  0: The maximum resident set size (KB)                   = 1127128
 
 Test 003 cpld_decomp_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/cpld_control_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/cpld_mpi_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/cpld_mpi_p8
 Checking test 004 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -269,14 +269,14 @@ Checking test 004 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 297.441398
-  0: The maximum resident set size (KB)                   = 1021636
+  0: The total amount of wall time                        = 295.568682
+  0: The maximum resident set size (KB)                   = 1044700
 
 Test 004 cpld_mpi_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/cpld_bmark_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/cpld_bmark_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_bmark_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/cpld_bmark_p8
 Checking test 005 cpld_bmark_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -322,14 +322,14 @@ Checking test 005 cpld_bmark_p8 results ....
  Comparing RESTART/iced.2013-04-01-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2013-04-01-21600.nc .........OK
 
-  0: The total amount of wall time                        = 1087.641383
-  0: The maximum resident set size (KB)                   = 2799904
+  0: The total amount of wall time                        = 1064.884887
+  0: The maximum resident set size (KB)                   = 2840748
 
 Test 005 cpld_bmark_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/cpld_control_c96_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/cpld_control_c96_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/cpld_control_c96_p8
 Checking test 006 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -392,14 +392,14 @@ Checking test 006 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 346.092001
-  0: The maximum resident set size (KB)                   = 1118360
+  0: The total amount of wall time                        = 345.417448
+  0: The maximum resident set size (KB)                   = 1146288
 
 Test 006 cpld_control_c96_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/cpld_control_c96_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/cpld_restart_c96_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_c96_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/cpld_restart_c96_p8
 Checking test 007 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -450,14 +450,14 @@ Checking test 007 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 194.705296
-  0: The maximum resident set size (KB)                   = 1078832
+  0: The total amount of wall time                        = 193.291603
+  0: The maximum resident set size (KB)                   = 1108528
 
 Test 007 cpld_restart_c96_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/cpld_control_c192_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/cpld_control_c192_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/cpld_control_c192_p8
 Checking test 008 cpld_control_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -508,14 +508,14 @@ Checking test 008 cpld_control_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 1464.818015
-  0: The maximum resident set size (KB)                   = 1565212
+  0: The total amount of wall time                        = 1472.913587
+  0: The maximum resident set size (KB)                   = 1584816
 
 Test 008 cpld_control_c192_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/cpld_control_c192_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/cpld_restart_c192_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_c192_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/cpld_restart_c192_p8
 Checking test 009 cpld_restart_c192_p8 results ....
  Comparing sfcf036.tile1.nc .........OK
  Comparing sfcf036.tile2.nc .........OK
@@ -566,14 +566,14 @@ Checking test 009 cpld_restart_c192_p8 results ....
  Comparing RESTART/iced.2021-03-23-64800.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-64800.nc .........OK
 
-  0: The total amount of wall time                        = 979.396302
-  0: The maximum resident set size (KB)                   = 1777468
+  0: The total amount of wall time                        = 981.378230
+  0: The maximum resident set size (KB)                   = 1812860
 
 Test 009 cpld_restart_c192_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/cpld_control_c384_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/cpld_control_c384_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_c384_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/cpld_control_c384_p8
 Checking test 010 cpld_control_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -617,14 +617,14 @@ Checking test 010 cpld_control_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1198.974850
-  0: The maximum resident set size (KB)                   = 2791768
+  0: The total amount of wall time                        = 1185.173624
+  0: The maximum resident set size (KB)                   = 2828312
 
 Test 010 cpld_control_c384_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/cpld_control_c384_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/cpld_restart_c384_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_c384_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/cpld_restart_c384_p8
 Checking test 011 cpld_restart_c384_p8 results ....
  Comparing sfcf006.nc .........OK
  Comparing atmf006.nc .........OK
@@ -668,14 +668,14 @@ Checking test 011 cpld_restart_c384_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 683.646013
-  0: The maximum resident set size (KB)                   = 2771332
+  0: The total amount of wall time                        = 679.458257
+  0: The maximum resident set size (KB)                   = 2805808
 
 Test 011 cpld_restart_c384_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/cpld_debug_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/cpld_debug_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/cpld_debug_p8
 Checking test 012 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -726,14 +726,14 @@ Checking test 012 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1016.383179
-  0: The maximum resident set size (KB)                   = 1222840
+  0: The total amount of wall time                        = 1024.771234
+  0: The maximum resident set size (KB)                   = 1270860
 
 Test 012 cpld_debug_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control
 Checking test 013 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -780,14 +780,14 @@ Checking test 013 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 129.153703
-  0: The maximum resident set size (KB)                   = 445188
+  0: The total amount of wall time                        = 132.954068
+  0: The maximum resident set size (KB)                   = 467972
 
 Test 013 control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_decomp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_decomp
 Checking test 014 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -830,28 +830,28 @@ Checking test 014 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 138.039930
-  0: The maximum resident set size (KB)                   = 452204
+  0: The total amount of wall time                        = 135.401063
+  0: The maximum resident set size (KB)                   = 464416
 
 Test 014 control_decomp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_2dwrtdecomp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_2dwrtdecomp
 Checking test 015 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 122.376088
-  0: The maximum resident set size (KB)                   = 450948
+  0: The total amount of wall time                        = 125.721176
+  0: The maximum resident set size (KB)                   = 464776
 
 Test 015 control_2dwrtdecomp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_2threads
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_2threads
 Checking test 016 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -894,14 +894,14 @@ Checking test 016 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 154.724079
- 0: The maximum resident set size (KB)                   = 503552
+ 0: The total amount of wall time                        = 153.281841
+ 0: The maximum resident set size (KB)                   = 517560
 
 Test 016 control_2threads PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_restart
 Checking test 017 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -940,14 +940,14 @@ Checking test 017 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 67.332461
-  0: The maximum resident set size (KB)                   = 197000
+  0: The total amount of wall time                        = 68.805654
+  0: The maximum resident set size (KB)                   = 209432
 
 Test 017 control_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_fhzero
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_fhzero
 Checking test 018 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -990,14 +990,14 @@ Checking test 018 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 125.333472
-  0: The maximum resident set size (KB)                   = 446884
+  0: The total amount of wall time                        = 121.833648
+  0: The maximum resident set size (KB)                   = 465036
 
 Test 018 control_fhzero PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_CubedSphereGrid
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_CubedSphereGrid
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_CubedSphereGrid
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_CubedSphereGrid
 Checking test 019 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -1024,14 +1024,14 @@ Checking test 019 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 126.243196
-  0: The maximum resident set size (KB)                   = 454420
+  0: The total amount of wall time                        = 123.587096
+  0: The maximum resident set size (KB)                   = 466232
 
 Test 019 control_CubedSphereGrid PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_latlon
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_latlon
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_latlon
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_latlon
 Checking test 020 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1042,14 +1042,14 @@ Checking test 020 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 129.384438
-  0: The maximum resident set size (KB)                   = 449084
+  0: The total amount of wall time                        = 126.094156
+  0: The maximum resident set size (KB)                   = 466080
 
 Test 020 control_latlon PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_wrtGauss_netcdf_parallel
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_wrtGauss_netcdf_parallel
 Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -1060,14 +1060,14 @@ Checking test 021 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 130.610754
-  0: The maximum resident set size (KB)                   = 447988
+  0: The total amount of wall time                        = 133.214620
+  0: The maximum resident set size (KB)                   = 466128
 
 Test 021 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_c48
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_c48
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_c48
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_c48
 Checking test 022 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1106,14 +1106,14 @@ Checking test 022 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 330.339003
-0: The maximum resident set size (KB)                   = 644520
+0: The total amount of wall time                        = 325.242214
+0: The maximum resident set size (KB)                   = 665640
 
 Test 022 control_c48 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_c192
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_c192
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_c192
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_c192
 Checking test 023 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1124,14 +1124,14 @@ Checking test 023 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 484.029448
-  0: The maximum resident set size (KB)                   = 547944
+  0: The total amount of wall time                        = 474.101294
+  0: The maximum resident set size (KB)                   = 566672
 
 Test 023 control_c192 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_c384
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_c384
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_c384
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_c384
 Checking test 024 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1142,14 +1142,14 @@ Checking test 024 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 652.825924
-  0: The maximum resident set size (KB)                   = 817656
+  0: The total amount of wall time                        = 645.809568
+  0: The maximum resident set size (KB)                   = 840856
 
 Test 024 control_c384 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_c384gdas
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_c384gdas
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_c384gdas
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_c384gdas
 Checking test 025 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -1192,14 +1192,14 @@ Checking test 025 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 599.248719
-  0: The maximum resident set size (KB)                   = 966560
+  0: The total amount of wall time                        = 595.866007
+  0: The maximum resident set size (KB)                   = 988696
 
 Test 025 control_c384gdas PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_stochy
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_stochy
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_stochy
 Checking test 026 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1210,28 +1210,28 @@ Checking test 026 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 83.415117
-  0: The maximum resident set size (KB)                   = 455820
+  0: The total amount of wall time                        = 83.815680
+  0: The maximum resident set size (KB)                   = 472272
 
 Test 026 control_stochy PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_stochy
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_stochy_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_stochy
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_stochy_restart
 Checking test 027 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 45.334387
-  0: The maximum resident set size (KB)                   = 229692
+  0: The total amount of wall time                        = 46.537330
+  0: The maximum resident set size (KB)                   = 249452
 
 Test 027 control_stochy_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_lndp
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_lndp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_lndp
 Checking test 028 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -1242,14 +1242,14 @@ Checking test 028 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 76.099805
-  0: The maximum resident set size (KB)                   = 452676
+  0: The total amount of wall time                        = 77.442090
+  0: The maximum resident set size (KB)                   = 468756
 
 Test 028 control_lndp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_iovr4
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_iovr4
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_iovr4
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_iovr4
 Checking test 029 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1264,14 +1264,14 @@ Checking test 029 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 131.378923
-  0: The maximum resident set size (KB)                   = 446880
+  0: The total amount of wall time                        = 132.477955
+  0: The maximum resident set size (KB)                   = 467860
 
 Test 029 control_iovr4 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_iovr5
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_iovr5
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_iovr5
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_iovr5
 Checking test 030 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1286,14 +1286,14 @@ Checking test 030 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 131.504410
-  0: The maximum resident set size (KB)                   = 448252
+  0: The total amount of wall time                        = 132.132544
+  0: The maximum resident set size (KB)                   = 469532
 
 Test 030 control_iovr5 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_p8
 Checking test 031 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1340,14 +1340,14 @@ Checking test 031 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 172.881217
-  0: The maximum resident set size (KB)                   = 839128
+  0: The total amount of wall time                        = 175.732532
+  0: The maximum resident set size (KB)                   = 854320
 
 Test 031 control_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_p8_lndp
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_p8_lndp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8_lndp
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_p8_lndp
 Checking test 032 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1366,14 +1366,14 @@ Checking test 032 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 329.359912
-  0: The maximum resident set size (KB)                   = 836764
+  0: The total amount of wall time                        = 325.911819
+  0: The maximum resident set size (KB)                   = 858260
 
 Test 032 control_p8_lndp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_restart_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_restart_p8
 Checking test 033 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1412,14 +1412,14 @@ Checking test 033 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 92.352777
-  0: The maximum resident set size (KB)                   = 579924
+  0: The total amount of wall time                        = 92.605055
+  0: The maximum resident set size (KB)                   = 602032
 
 Test 033 control_restart_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_decomp_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_decomp_p8
 Checking test 034 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1462,14 +1462,14 @@ Checking test 034 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 177.351235
-  0: The maximum resident set size (KB)                   = 833120
+  0: The total amount of wall time                        = 181.807524
+  0: The maximum resident set size (KB)                   = 847596
 
 Test 034 control_decomp_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_2threads_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_2threads_p8
 Checking test 035 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1512,14 +1512,14 @@ Checking test 035 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 203.675829
- 0: The maximum resident set size (KB)                   = 914248
+ 0: The total amount of wall time                        = 202.606655
+ 0: The maximum resident set size (KB)                   = 933616
 
 Test 035 control_2threads_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_p8_rrtmgp
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_p8_rrtmgp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_p8_rrtmgp
 Checking test 036 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1566,14 +1566,14 @@ Checking test 036 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 200.495762
-  0: The maximum resident set size (KB)                   = 957484
+  0: The total amount of wall time                        = 203.889231
+  0: The maximum resident set size (KB)                   = 973076
 
 Test 036 control_p8_rrtmgp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/fv3_regional_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/regional_control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/regional_control
 Checking test 037 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1584,42 +1584,42 @@ Checking test 037 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 330.264489
- 0: The maximum resident set size (KB)                   = 566164
+ 0: The total amount of wall time                        = 328.420675
+ 0: The maximum resident set size (KB)                   = 581716
 
 Test 037 regional_control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/fv3_regional_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/regional_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/regional_restart
 Checking test 038 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 181.739977
- 0: The maximum resident set size (KB)                   = 559904
+ 0: The total amount of wall time                        = 181.866384
+ 0: The maximum resident set size (KB)                   = 585784
 
 Test 038 regional_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/fv3_regional_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/regional_control_2dwrtdecomp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/regional_control_2dwrtdecomp
 Checking test 039 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 332.063658
- 0: The maximum resident set size (KB)                   = 562840
+ 0: The total amount of wall time                        = 331.655753
+ 0: The maximum resident set size (KB)                   = 581912
 
 Test 039 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/fv3_regional_noquilt
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/regional_noquilt
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_noquilt
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/regional_noquilt
 Checking test 040 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1627,14 +1627,14 @@ Checking test 040 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 344.325214
- 0: The maximum resident set size (KB)                   = 575140
+ 0: The total amount of wall time                        = 341.828081
+ 0: The maximum resident set size (KB)                   = 596164
 
 Test 040 regional_noquilt PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/fv3_regional_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/regional_2threads
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/regional_2threads
 Checking test 041 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1645,28 +1645,28 @@ Checking test 041 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 245.772714
- 0: The maximum resident set size (KB)                   = 562720
+ 0: The total amount of wall time                        = 236.669675
+ 0: The maximum resident set size (KB)                   = 582508
 
 Test 041 regional_2threads PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/fv3_regional_netcdf_parallel
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/regional_netcdf_parallel
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_netcdf_parallel
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/regional_netcdf_parallel
 Checking test 042 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 326.967154
- 0: The maximum resident set size (KB)                   = 560320
+ 0: The total amount of wall time                        = 325.572905
+ 0: The maximum resident set size (KB)                   = 580628
 
 Test 042 regional_netcdf_parallel PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/fv3_regional_3km
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/regional_3km
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_3km
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/regional_3km
 Checking test 043 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1677,28 +1677,28 @@ Checking test 043 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 262.314939
-  0: The maximum resident set size (KB)                   = 598756
+  0: The total amount of wall time                        = 264.420993
+  0: The maximum resident set size (KB)                   = 621332
 
 Test 043 regional_3km PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hrrr_control_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hrrr_control_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hrrr_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hrrr_control_debug
 Checking test 044 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 258.341250
-  0: The maximum resident set size (KB)                   = 963256
+  0: The total amount of wall time                        = 260.537707
+  0: The maximum resident set size (KB)                   = 1000864
 
 Test 044 hrrr_control_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_control
 Checking test 045 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1745,14 +1745,14 @@ Checking test 045 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 441.080415
-  0: The maximum resident set size (KB)                   = 826520
+  0: The total amount of wall time                        = 458.393212
+  0: The maximum resident set size (KB)                   = 842248
 
 Test 045 rap_control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_rrtmgp
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_rrtmgp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_rrtmgp
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_rrtmgp
 Checking test 046 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1799,14 +1799,14 @@ Checking test 046 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 472.725477
-  0: The maximum resident set size (KB)                   = 945772
+  0: The total amount of wall time                        = 485.853149
+  0: The maximum resident set size (KB)                   = 958976
 
 Test 046 rap_rrtmgp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/regional_spp_sppt_shum_skeb
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/regional_spp_sppt_shum_skeb
 Checking test 047 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1817,14 +1817,14 @@ Checking test 047 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 307.311894
-  0: The maximum resident set size (KB)                   = 1191804
+  0: The total amount of wall time                        = 306.125130
+  0: The maximum resident set size (KB)                   = 1217912
 
 Test 047 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_decomp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_decomp
 Checking test 048 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1871,14 +1871,14 @@ Checking test 048 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 463.190101
-  0: The maximum resident set size (KB)                   = 823708
+  0: The total amount of wall time                        = 470.847554
+  0: The maximum resident set size (KB)                   = 840740
 
 Test 048 rap_decomp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_2threads
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_2threads
 Checking test 049 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1925,14 +1925,14 @@ Checking test 049 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 517.306914
- 0: The maximum resident set size (KB)                   = 888192
+ 0: The total amount of wall time                        = 516.050440
+ 0: The maximum resident set size (KB)                   = 905916
 
 Test 049 rap_2threads PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_restart
 Checking test 050 rap_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1971,14 +1971,14 @@ Checking test 050 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 334.054070
-  0: The maximum resident set size (KB)                   = 577936
+  0: The total amount of wall time                        = 330.001733
+  0: The maximum resident set size (KB)                   = 596024
 
 Test 050 rap_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_sfcdiff
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_sfcdiff
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_sfcdiff
 Checking test 051 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2025,14 +2025,14 @@ Checking test 051 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 446.826455
-  0: The maximum resident set size (KB)                   = 828832
+  0: The total amount of wall time                        = 446.362107
+  0: The maximum resident set size (KB)                   = 846272
 
 Test 051 rap_sfcdiff PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_sfcdiff
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_sfcdiff_decomp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_sfcdiff_decomp
 Checking test 052 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2079,14 +2079,14 @@ Checking test 052 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 471.069200
-  0: The maximum resident set size (KB)                   = 826064
+  0: The total amount of wall time                        = 471.886033
+  0: The maximum resident set size (KB)                   = 842520
 
 Test 052 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_sfcdiff
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_sfcdiff_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_sfcdiff
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_sfcdiff_restart
 Checking test 053 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2125,14 +2125,14 @@ Checking test 053 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 330.402189
-  0: The maximum resident set size (KB)                   = 581456
+  0: The total amount of wall time                        = 335.788539
+  0: The maximum resident set size (KB)                   = 599384
 
 Test 053 rap_sfcdiff_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hrrr_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hrrr_control
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hrrr_control
 Checking test 054 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2179,14 +2179,14 @@ Checking test 054 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 421.782132
-  0: The maximum resident set size (KB)                   = 825788
+  0: The total amount of wall time                        = 423.734012
+  0: The maximum resident set size (KB)                   = 838584
 
 Test 054 hrrr_control PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hrrr_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hrrr_control_decomp
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hrrr_control_decomp
 Checking test 055 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2233,14 +2233,14 @@ Checking test 055 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 447.792887
-  0: The maximum resident set size (KB)                   = 827300
+  0: The total amount of wall time                        = 447.683479
+  0: The maximum resident set size (KB)                   = 841724
 
 Test 055 hrrr_control_decomp PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hrrr_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hrrr_control_2threads
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hrrr_control_2threads
 Checking test 056 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2287,14 +2287,14 @@ Checking test 056 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 492.232905
- 0: The maximum resident set size (KB)                   = 883852
+ 0: The total amount of wall time                        = 493.811746
+ 0: The maximum resident set size (KB)                   = 901144
 
 Test 056 hrrr_control_2threads PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hrrr_control
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hrrr_control_restart
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hrrr_control
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hrrr_control_restart
 Checking test 057 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2333,14 +2333,14 @@ Checking test 057 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 318.430010
-  0: The maximum resident set size (KB)                   = 574728
+  0: The total amount of wall time                        = 325.211167
+  0: The maximum resident set size (KB)                   = 590148
 
 Test 057 hrrr_control_restart PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rrfs_v1beta
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rrfs_v1beta
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_v1beta
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rrfs_v1beta
 Checking test 058 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2387,14 +2387,14 @@ Checking test 058 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 428.709695
-  0: The maximum resident set size (KB)                   = 818312
+  0: The total amount of wall time                        = 440.155180
+  0: The maximum resident set size (KB)                   = 841892
 
 Test 058 rrfs_v1beta PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rrfs_v1nssl
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rrfs_v1nssl
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_v1nssl
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rrfs_v1nssl
 Checking test 059 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2409,14 +2409,14 @@ Checking test 059 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 477.445674
-  0: The maximum resident set size (KB)                   = 511272
+  0: The total amount of wall time                        = 477.786333
+  0: The maximum resident set size (KB)                   = 528312
 
 Test 059 rrfs_v1nssl PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rrfs_v1nssl_nohailnoccn
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rrfs_v1nssl_nohailnoccn
 Checking test 060 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2431,14 +2431,14 @@ Checking test 060 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 456.003717
-  0: The maximum resident set size (KB)                   = 502268
+  0: The total amount of wall time                        = 460.827749
+  0: The maximum resident set size (KB)                   = 520756
 
 Test 060 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rrfs_conus13km_hrrr_warm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rrfs_conus13km_hrrr_warm
 Checking test 061 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2447,14 +2447,14 @@ Checking test 061 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 179.480442
-  0: The maximum resident set size (KB)                   = 651396
+  0: The total amount of wall time                        = 177.241684
+  0: The maximum resident set size (KB)                   = 671616
 
 Test 061 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rrfs_conus13km_radar_tten_warm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rrfs_conus13km_radar_tten_warm
 Checking test 062 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2463,14 +2463,14 @@ Checking test 062 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 185.209315
-  0: The maximum resident set size (KB)                   = 656108
+  0: The total amount of wall time                        = 180.890625
+  0: The maximum resident set size (KB)                   = 674664
 
 Test 062 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rrfs_smoke_conus13km_hrrr_warm
 Checking test 063 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2479,14 +2479,14 @@ Checking test 063 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 196.968188
-  0: The maximum resident set size (KB)                   = 668928
+  0: The total amount of wall time                        = 197.305772
+  0: The maximum resident set size (KB)                   = 689360
 
 Test 063 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_p8_gf_mynn_hfip
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_p8_gf_mynn_hfip
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8_gf_mynn_hfip
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_p8_gf_mynn_hfip
 Checking test 064 control_p8_gf_mynn_hfip results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2533,14 +2533,14 @@ Checking test 064 control_p8_gf_mynn_hfip results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 278.324175
-  0: The maximum resident set size (KB)                   = 850524
+  0: The total amount of wall time                        = 274.672349
+  0: The maximum resident set size (KB)                   = 865612
 
 Test 064 control_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_p8_gf_mynn_hfip
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_decomp_p8_gf_mynn_hfip
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8_gf_mynn_hfip
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_decomp_p8_gf_mynn_hfip
 Checking test 065 control_decomp_p8_gf_mynn_hfip results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2583,14 +2583,14 @@ Checking test 065 control_decomp_p8_gf_mynn_hfip results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 291.645720
-  0: The maximum resident set size (KB)                   = 845440
+  0: The total amount of wall time                        = 283.323671
+  0: The maximum resident set size (KB)                   = 860080
 
 Test 065 control_decomp_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_p8_gf_mynn_hfip
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_2threads_p8_gf_mynn_hfip
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8_gf_mynn_hfip
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_2threads_p8_gf_mynn_hfip
 Checking test 066 control_2threads_p8_gf_mynn_hfip results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2633,14 +2633,14 @@ Checking test 066 control_2threads_p8_gf_mynn_hfip results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 330.257927
- 0: The maximum resident set size (KB)                   = 927528
+ 0: The total amount of wall time                        = 332.652768
+ 0: The maximum resident set size (KB)                   = 952688
 
 Test 066 control_2threads_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_p8_gf_mynn_hfip
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_restart_p8_gf_mynn_hfip
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8_gf_mynn_hfip
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_restart_p8_gf_mynn_hfip
 Checking test 067 control_restart_p8_gf_mynn_hfip results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2679,14 +2679,14 @@ Checking test 067 control_restart_p8_gf_mynn_hfip results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 141.738880
-  0: The maximum resident set size (KB)                   = 595032
+  0: The total amount of wall time                        = 146.827559
+  0: The maximum resident set size (KB)                   = 619428
 
 Test 067 control_restart_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_csawmg
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_csawmg
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_csawmg
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_csawmg
 Checking test 068 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2697,14 +2697,14 @@ Checking test 068 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 329.416970
-  0: The maximum resident set size (KB)                   = 518760
+  0: The total amount of wall time                        = 321.427565
+  0: The maximum resident set size (KB)                   = 534728
 
 Test 068 control_csawmg PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_csawmgt
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_csawmgt
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_csawmgt
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_csawmgt
 Checking test 069 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2715,14 +2715,14 @@ Checking test 069 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 324.760581
-  0: The maximum resident set size (KB)                   = 520232
+  0: The total amount of wall time                        = 325.204646
+  0: The maximum resident set size (KB)                   = 537200
 
 Test 069 control_csawmgt PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_flake
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_flake
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_flake
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_flake
 Checking test 070 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2733,14 +2733,14 @@ Checking test 070 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 234.274711
-  0: The maximum resident set size (KB)                   = 521136
+  0: The total amount of wall time                        = 236.549847
+  0: The maximum resident set size (KB)                   = 532532
 
 Test 070 control_flake PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_ras
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_ras
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_ras
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_ras
 Checking test 071 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2751,14 +2751,14 @@ Checking test 071 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 173.147685
-  0: The maximum resident set size (KB)                   = 478224
+  0: The total amount of wall time                        = 174.221363
+  0: The maximum resident set size (KB)                   = 497636
 
 Test 071 control_ras PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_thompson
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_thompson
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_thompson
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_thompson
 Checking test 072 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2769,14 +2769,14 @@ Checking test 072 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 236.487083
-  0: The maximum resident set size (KB)                   = 835568
+  0: The total amount of wall time                        = 239.284043
+  0: The maximum resident set size (KB)                   = 850772
 
 Test 072 control_thompson PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_thompson_no_aero
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_thompson_no_aero
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_thompson_no_aero
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_thompson_no_aero
 Checking test 073 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2787,54 +2787,54 @@ Checking test 073 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 226.432198
-  0: The maximum resident set size (KB)                   = 826832
+  0: The total amount of wall time                        = 226.244758
+  0: The maximum resident set size (KB)                   = 844968
 
 Test 073 control_thompson_no_aero PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_wam
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_wam
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_wam
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_wam
 Checking test 074 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 103.402178
-  0: The maximum resident set size (KB)                   = 217744
+  0: The total amount of wall time                        = 110.901430
+  0: The maximum resident set size (KB)                   = 232824
 
 Test 074 control_wam PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_debug
 Checking test 075 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 142.948128
-  0: The maximum resident set size (KB)                   = 590248
+  0: The total amount of wall time                        = 147.462748
+  0: The maximum resident set size (KB)                   = 630724
 
 Test 075 control_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_2threads_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_2threads_debug
 Checking test 076 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 214.254729
- 0: The maximum resident set size (KB)                   = 644432
+ 0: The total amount of wall time                        = 218.044509
+ 0: The maximum resident set size (KB)                   = 674492
 
 Test 076 control_2threads_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_CubedSphereGrid_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_CubedSphereGrid_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_CubedSphereGrid_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_CubedSphereGrid_debug
 Checking test 077 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2861,429 +2861,429 @@ Checking test 077 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 162.637027
-  0: The maximum resident set size (KB)                   = 593660
+  0: The total amount of wall time                        = 157.376761
+  0: The maximum resident set size (KB)                   = 630256
 
 Test 077 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_wrtGauss_netcdf_parallel_debug
 Checking test 078 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 145.818227
-  0: The maximum resident set size (KB)                   = 591620
+  0: The total amount of wall time                        = 145.594839
+  0: The maximum resident set size (KB)                   = 629316
 
 Test 078 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_stochy_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_stochy_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_stochy_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_stochy_debug
 Checking test 079 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 163.636074
-  0: The maximum resident set size (KB)                   = 598020
+  0: The total amount of wall time                        = 167.077833
+  0: The maximum resident set size (KB)                   = 637864
 
 Test 079 control_stochy_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_lndp_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_lndp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_lndp_debug
 Checking test 080 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 146.889958
-  0: The maximum resident set size (KB)                   = 596852
+  0: The total amount of wall time                        = 149.635924
+  0: The maximum resident set size (KB)                   = 634868
 
 Test 080 control_lndp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_csawmg_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_csawmg_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_csawmg_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_csawmg_debug
 Checking test 081 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 226.960150
-  0: The maximum resident set size (KB)                   = 638656
+  0: The total amount of wall time                        = 224.463541
+  0: The maximum resident set size (KB)                   = 674420
 
 Test 081 control_csawmg_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_csawmgt_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_csawmgt_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_csawmgt_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_csawmgt_debug
 Checking test 082 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 221.967233
-  0: The maximum resident set size (KB)                   = 633808
+  0: The total amount of wall time                        = 218.485190
+  0: The maximum resident set size (KB)                   = 677380
 
 Test 082 control_csawmgt_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_ras_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_ras_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_ras_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_ras_debug
 Checking test 083 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 149.916798
-  0: The maximum resident set size (KB)                   = 604920
+  0: The total amount of wall time                        = 148.255375
+  0: The maximum resident set size (KB)                   = 643336
 
 Test 083 control_ras_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_diag_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_diag_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_diag_debug
 Checking test 084 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 158.111375
-  0: The maximum resident set size (KB)                   = 652148
+  0: The total amount of wall time                        = 154.953508
+  0: The maximum resident set size (KB)                   = 689488
 
 Test 084 control_diag_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_debug_p8
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_debug_p8
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_debug_p8
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_debug_p8
 Checking test 085 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 164.275256
-  0: The maximum resident set size (KB)                   = 984216
+  0: The total amount of wall time                        = 161.799338
+  0: The maximum resident set size (KB)                   = 1017120
 
 Test 085 control_debug_p8 PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_thompson_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_thompson_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_thompson_debug
 Checking test 086 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 171.022837
-  0: The maximum resident set size (KB)                   = 958400
+  0: The total amount of wall time                        = 170.446933
+  0: The maximum resident set size (KB)                   = 993144
 
 Test 086 control_thompson_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_thompson_no_aero_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_thompson_no_aero_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_thompson_no_aero_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_thompson_no_aero_debug
 Checking test 087 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 165.704381
-  0: The maximum resident set size (KB)                   = 946424
+  0: The total amount of wall time                        = 162.394020
+  0: The maximum resident set size (KB)                   = 986692
 
 Test 087 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_thompson_debug_extdiag
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_thompson_extdiag_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_thompson_debug_extdiag
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_thompson_extdiag_debug
 Checking test 088 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 181.494626
-  0: The maximum resident set size (KB)                   = 988596
+  0: The total amount of wall time                        = 182.491545
+  0: The maximum resident set size (KB)                   = 1021764
 
 Test 088 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_thompson_progcld_thompson_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_thompson_progcld_thompson_debug
 Checking test 089 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 169.998839
-  0: The maximum resident set size (KB)                   = 955748
+  0: The total amount of wall time                        = 168.449127
+  0: The maximum resident set size (KB)                   = 995280
 
 Test 089 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/fv3_regional_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/regional_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/regional_debug
 Checking test 090 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 237.275112
- 0: The maximum resident set size (KB)                   = 552044
+ 0: The total amount of wall time                        = 234.938840
+ 0: The maximum resident set size (KB)                   = 606772
 
 Test 090 regional_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_control_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_control_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_control_debug
 Checking test 091 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 265.586641
-  0: The maximum resident set size (KB)                   = 964740
+  0: The total amount of wall time                        = 263.649250
+  0: The maximum resident set size (KB)                   = 1000544
 
 Test 091 rap_control_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_control_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_unified_drag_suite_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_control_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_unified_drag_suite_debug
 Checking test 092 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 264.641828
-  0: The maximum resident set size (KB)                   = 961864
+  0: The total amount of wall time                        = 266.050196
+  0: The maximum resident set size (KB)                   = 1005812
 
 Test 092 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_diag_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_diag_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_diag_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_diag_debug
 Checking test 093 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 278.936021
-  0: The maximum resident set size (KB)                   = 1046684
+  0: The total amount of wall time                        = 277.933008
+  0: The maximum resident set size (KB)                   = 1088120
 
 Test 093 rap_diag_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_cires_ugwp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_cires_ugwp_debug
 Checking test 094 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 270.707862
-  0: The maximum resident set size (KB)                   = 964000
+  0: The total amount of wall time                        = 271.276857
+  0: The maximum resident set size (KB)                   = 1003000
 
 Test 094 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_cires_ugwp_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_unified_ugwp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_unified_ugwp_debug
 Checking test 095 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 272.014668
-  0: The maximum resident set size (KB)                   = 965580
+  0: The total amount of wall time                        = 269.343720
+  0: The maximum resident set size (KB)                   = 1003172
 
 Test 095 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_lndp_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_lndp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_lndp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_lndp_debug
 Checking test 096 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 268.867216
-  0: The maximum resident set size (KB)                   = 966156
+  0: The total amount of wall time                        = 264.351195
+  0: The maximum resident set size (KB)                   = 1001220
 
 Test 096 rap_lndp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_flake_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_flake_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_flake_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_flake_debug
 Checking test 097 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.833226
-  0: The maximum resident set size (KB)                   = 967176
+  0: The total amount of wall time                        = 269.455728
+  0: The maximum resident set size (KB)                   = 1005132
 
 Test 097 rap_flake_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_progcld_thompson_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_progcld_thompson_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_progcld_thompson_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_progcld_thompson_debug
 Checking test 098 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 260.156238
-  0: The maximum resident set size (KB)                   = 965848
+  0: The total amount of wall time                        = 262.148809
+  0: The maximum resident set size (KB)                   = 1004652
 
 Test 098 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_debug_p8_gf_mynn_hfip
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_debug_p8_gf_mynn_hfip
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_debug_p8_gf_mynn_hfip
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_debug_p8_gf_mynn_hfip
 Checking test 099 control_debug_p8_gf_mynn_hfip results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 230.703638
-  0: The maximum resident set size (KB)                   = 990656
+  0: The total amount of wall time                        = 228.052178
+  0: The maximum resident set size (KB)                   = 1029748
 
 Test 099 control_debug_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_noah_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_noah_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_noah_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_noah_debug
 Checking test 100 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 259.647302
-  0: The maximum resident set size (KB)                   = 969496
+  0: The total amount of wall time                        = 258.558721
+  0: The maximum resident set size (KB)                   = 1001320
 
 Test 100 rap_noah_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_rrtmgp_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_rrtmgp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_rrtmgp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_rrtmgp_debug
 Checking test 101 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 443.986567
-  0: The maximum resident set size (KB)                   = 1083612
+  0: The total amount of wall time                        = 445.963901
+  0: The maximum resident set size (KB)                   = 1129480
 
 Test 101 rap_rrtmgp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_sfcdiff_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_sfcdiff_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_sfcdiff_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_sfcdiff_debug
 Checking test 102 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 264.454948
-  0: The maximum resident set size (KB)                   = 963340
+  0: The total amount of wall time                        = 266.048999
+  0: The maximum resident set size (KB)                   = 999836
 
 Test 102 rap_sfcdiff_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 103 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 440.588432
-  0: The maximum resident set size (KB)                   = 965004
+  0: The total amount of wall time                        = 436.853282
+  0: The maximum resident set size (KB)                   = 998844
 
 Test 103 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/rrfs_v1beta_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/rrfs_v1beta_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_v1beta_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/rrfs_v1beta_debug
 Checking test 104 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 263.587057
-  0: The maximum resident set size (KB)                   = 963172
+  0: The total amount of wall time                        = 258.101536
+  0: The maximum resident set size (KB)                   = 1002652
 
 Test 104 rrfs_v1beta_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_wam_debug
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_wam_debug
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_wam_debug
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_wam_debug
 Checking test 105 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 276.298058
-  0: The maximum resident set size (KB)                   = 207776
+  0: The total amount of wall time                        = 275.554198
+  0: The maximum resident set size (KB)                   = 257692
 
 Test 105 control_wam_debug PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_atm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_atm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_atm
 Checking test 106 hafs_regional_atm results ....
- Comparing atmf006.nc ............ALT CHECK......OK
- Comparing sfcf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
+ Comparing sfcf006.nc .........OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 270.222207
-  0: The maximum resident set size (KB)                   = 697868
+  0: The total amount of wall time                        = 286.964402
+  0: The maximum resident set size (KB)                   = 711848
 
 Test 106 hafs_regional_atm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_atm_thompson_gfdlsf
 Checking test 107 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 345.057178
-  0: The maximum resident set size (KB)                   = 1050884
+  0: The total amount of wall time                        = 339.994584
+  0: The maximum resident set size (KB)                   = 1074804
 
 Test 107 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_atm_ocn
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_atm_ocn
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_atm_ocn
 Checking test 108 hafs_regional_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3292,28 +3292,28 @@ Checking test 108 hafs_regional_atm_ocn results ....
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 346.385063
-  0: The maximum resident set size (KB)                   = 734472
+  0: The total amount of wall time                        = 352.414593
+  0: The maximum resident set size (KB)                   = 761220
 
 Test 108 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_atm_wav
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_atm_wav
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_atm_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_atm_wav
 Checking test 109 hafs_regional_atm_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 828.621428
-  0: The maximum resident set size (KB)                   = 719808
+  0: The total amount of wall time                        = 831.083739
+  0: The maximum resident set size (KB)                   = 753444
 
 Test 109 hafs_regional_atm_wav PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_atm_ocn_wav
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_atm_ocn_wav
 Checking test 110 hafs_regional_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3322,28 +3322,28 @@ Checking test 110 hafs_regional_atm_ocn_wav results ....
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 913.867078
-  0: The maximum resident set size (KB)                   = 744404
+  0: The total amount of wall time                        = 931.218385
+  0: The maximum resident set size (KB)                   = 766896
 
 Test 110 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_1nest_atm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_1nest_atm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_1nest_atm
 Checking test 111 hafs_regional_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 448.473215
-  0: The maximum resident set size (KB)                   = 302816
+  0: The total amount of wall time                        = 444.693939
+  0: The maximum resident set size (KB)                   = 317148
 
 Test 111 hafs_regional_1nest_atm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_telescopic_2nests_atm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_telescopic_2nests_atm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_telescopic_2nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_telescopic_2nests_atm
 Checking test 112 hafs_regional_telescopic_2nests_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3352,30 +3352,30 @@ Checking test 112 hafs_regional_telescopic_2nests_atm results ....
  Comparing atm.nest03.f006.nc .........OK
  Comparing sfc.nest03.f006.nc .........OK
 
-  0: The total amount of wall time                        = 465.993707
-  0: The maximum resident set size (KB)                   = 305124
+  0: The total amount of wall time                        = 465.826489
+  0: The maximum resident set size (KB)                   = 324820
 
 Test 112 hafs_regional_telescopic_2nests_atm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_global_1nest_atm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_global_1nest_atm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_global_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_global_1nest_atm
 Checking test 113 hafs_global_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 213.568125
-  0: The maximum resident set size (KB)                   = 190020
+  0: The total amount of wall time                        = 208.592336
+  0: The maximum resident set size (KB)                   = 220040
 
 Test 113 hafs_global_1nest_atm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_global_multiple_4nests_atm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_global_multiple_4nests_atm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_global_multiple_4nests_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_global_multiple_4nests_atm
 Checking test 114 hafs_global_multiple_4nests_atm results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
@@ -3386,28 +3386,28 @@ Checking test 114 hafs_global_multiple_4nests_atm results ....
  Comparing atm.nest05.f006.nc .........OK
  Comparing sfc.nest05.f006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 568.034476
-  0: The maximum resident set size (KB)                   = 240628
+  0: The total amount of wall time                        = 564.582957
+  0: The maximum resident set size (KB)                   = 281504
 
 Test 114 hafs_global_multiple_4nests_atm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_specified_moving_1nest_atm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_specified_moving_1nest_atm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_specified_moving_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_specified_moving_1nest_atm
 Checking test 115 hafs_regional_specified_moving_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
 
-  0: The total amount of wall time                        = 266.007603
-  0: The maximum resident set size (KB)                   = 304388
+  0: The total amount of wall time                        = 267.224481
+  0: The maximum resident set size (KB)                   = 321320
 
 Test 115 hafs_regional_specified_moving_1nest_atm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_storm_following_1nest_atm_ocn
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_storm_following_1nest_atm_ocn
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_storm_following_1nest_atm_ocn
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_storm_following_1nest_atm_ocn
 Checking test 116 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3416,46 +3416,46 @@ Checking test 116 hafs_regional_storm_following_1nest_atm_ocn results ....
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
 
-  0: The total amount of wall time                        = 264.063129
-  0: The maximum resident set size (KB)                   = 332408
+  0: The total amount of wall time                        = 263.452405
+  0: The maximum resident set size (KB)                   = 352676
 
 Test 116 hafs_regional_storm_following_1nest_atm_ocn PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_storm_following_1nest_atm_ocn_wav
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_storm_following_1nest_atm_ocn_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_storm_following_1nest_atm_ocn_wav
 Checking test 117 hafs_regional_storm_following_1nest_atm_ocn_wav results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
- Comparing atm.nest02.f006.nc .........OK
+ Comparing atm.nest02.f006.nc ............ALT CHECK......OK
  Comparing sfc.nest02.f006.nc ............ALT CHECK......OK
  Comparing archv.2020_238_18.a .........OK
  Comparing archs.2020_238_18.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 767.670218
-  0: The maximum resident set size (KB)                   = 352360
+  0: The total amount of wall time                        = 765.718032
+  0: The maximum resident set size (KB)                   = 370648
 
 Test 117 hafs_regional_storm_following_1nest_atm_ocn_wav PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_global_storm_following_1nest_atm
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_global_storm_following_1nest_atm
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_global_storm_following_1nest_atm
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_global_storm_following_1nest_atm
 Checking test 118 hafs_global_storm_following_1nest_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing atm.nest02.f006.nc .........OK
  Comparing sfc.nest02.f006.nc .........OK
 
-  0: The total amount of wall time                        = 82.180073
-  0: The maximum resident set size (KB)                   = 201220
+  0: The total amount of wall time                        = 81.111187
+  0: The maximum resident set size (KB)                   = 220820
 
 Test 118 hafs_global_storm_following_1nest_atm PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_docn
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_docn
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_docn
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_docn
 Checking test 119 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3463,14 +3463,14 @@ Checking test 119 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 355.700506
-  0: The maximum resident set size (KB)                   = 753892
+  0: The total amount of wall time                        = 356.349412
+  0: The maximum resident set size (KB)                   = 781680
 
 Test 119 hafs_regional_docn PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_docn_oisst
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_docn_oisst
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_docn_oisst
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_docn_oisst
 Checking test 120 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3478,118 +3478,118 @@ Checking test 120 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 348.643877
-  0: The maximum resident set size (KB)                   = 724688
+  0: The total amount of wall time                        = 355.826924
+  0: The maximum resident set size (KB)                   = 751356
 
 Test 120 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/hafs_regional_datm_cdeps
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/hafs_regional_datm_cdeps
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_datm_cdeps
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/hafs_regional_datm_cdeps
 Checking test 121 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 944.940987
-  0: The maximum resident set size (KB)                   = 850600
+  0: The total amount of wall time                        = 940.380364
+  0: The maximum resident set size (KB)                   = 853732
 
 Test 121 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_control_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_control_cfsr
 Checking test 122 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 139.946060
- 0: The maximum resident set size (KB)                   = 729980
+ 0: The total amount of wall time                        = 142.990743
+ 0: The maximum resident set size (KB)                   = 719400
 
 Test 122 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_restart_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_restart_cfsr
 Checking test 123 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 85.029303
- 0: The maximum resident set size (KB)                   = 708588
+ 0: The total amount of wall time                        = 81.188000
+ 0: The maximum resident set size (KB)                   = 719324
 
 Test 123 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_control_gefs
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_control_gefs
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_control_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_control_gefs
 Checking test 124 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 136.699285
- 0: The maximum resident set size (KB)                   = 609520
+ 0: The total amount of wall time                        = 138.790279
+ 0: The maximum resident set size (KB)                   = 617268
 
 Test 124 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_iau_gefs
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_iau_gefs
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_iau_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_iau_gefs
 Checking test 125 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 138.972494
- 0: The maximum resident set size (KB)                   = 608456
+ 0: The total amount of wall time                        = 139.391920
+ 0: The maximum resident set size (KB)                   = 619828
 
 Test 125 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_stochy_gefs
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_stochy_gefs
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_stochy_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_stochy_gefs
 Checking test 126 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 138.300682
- 0: The maximum resident set size (KB)                   = 611208
+ 0: The total amount of wall time                        = 138.099575
+ 0: The maximum resident set size (KB)                   = 619492
 
 Test 126 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_bulk_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_bulk_cfsr
 Checking test 127 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 141.845601
- 0: The maximum resident set size (KB)                   = 707892
+ 0: The total amount of wall time                        = 142.133613
+ 0: The maximum resident set size (KB)                   = 720108
 
 Test 127 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_bulk_gefs
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_bulk_gefs
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_bulk_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_bulk_gefs
 Checking test 128 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 137.264794
- 0: The maximum resident set size (KB)                   = 609708
+ 0: The total amount of wall time                        = 138.006696
+ 0: The maximum resident set size (KB)                   = 620324
 
 Test 128 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_mx025_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_mx025_cfsr
 Checking test 129 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3598,14 +3598,14 @@ Checking test 129 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 305.496747
-  0: The maximum resident set size (KB)                   = 560588
+  0: The total amount of wall time                        = 308.769796
+  0: The maximum resident set size (KB)                   = 565200
 
 Test 129 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_mx025_gefs
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_mx025_gefs
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_mx025_gefs
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_mx025_gefs
 Checking test 130 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3614,64 +3614,64 @@ Checking test 130 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 303.275392
-  0: The maximum resident set size (KB)                   = 521596
+  0: The total amount of wall time                        = 306.658457
+  0: The maximum resident set size (KB)                   = 533384
 
 Test 130 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_control_cfsr
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_multiple_files_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_control_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_multiple_files_cfsr
 Checking test 131 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 142.609872
- 0: The maximum resident set size (KB)                   = 710792
+ 0: The total amount of wall time                        = 145.594237
+ 0: The maximum resident set size (KB)                   = 718676
 
 Test 131 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_3072x1536_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_3072x1536_cfsr
 Checking test 132 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 192.007191
- 0: The maximum resident set size (KB)                   = 1825748
+ 0: The total amount of wall time                        = 195.181341
+ 0: The maximum resident set size (KB)                   = 1830840
 
 Test 132 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_gfs
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_gfs
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_gfs
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_gfs
 Checking test 133 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 193.743281
- 0: The maximum resident set size (KB)                   = 1822316
+ 0: The total amount of wall time                        = 206.367094
+ 0: The maximum resident set size (KB)                   = 1895540
 
 Test 133 datm_cdeps_gfs PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/datm_cdeps_debug_cfsr
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/datm_cdeps_debug_cfsr
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_debug_cfsr
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/datm_cdeps_debug_cfsr
 Checking test 134 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 431.414093
- 0: The maximum resident set size (KB)                   = 711200
+ 0: The total amount of wall time                        = 427.840071
+ 0: The maximum resident set size (KB)                   = 725132
 
 Test 134 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_atmwav
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_atmwav
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_atmwav
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_atmwav
 Checking test 135 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3715,14 +3715,14 @@ Checking test 135 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 83.563438
-  0: The maximum resident set size (KB)                   = 477264
+  0: The total amount of wall time                        = 81.516752
+  0: The maximum resident set size (KB)                   = 496520
 
 Test 135 control_atmwav PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_c384gdas_wav
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_c384gdas_wav
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_c384gdas_wav
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_c384gdas_wav
 Checking test 136 control_c384gdas_wav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf003.nc .........OK
@@ -3768,14 +3768,14 @@ Checking test 136 control_c384gdas_wav results ....
  Comparing 20210322.030000.restart.gnh_10m .........OK
  Comparing 20210322.030000.restart.gsh_15m .........OK
 
-  0: The total amount of wall time                        = 702.148729
-  0: The maximum resident set size (KB)                   = 1032724
+  0: The total amount of wall time                        = 701.394171
+  0: The maximum resident set size (KB)                   = 1050312
 
 Test 136 control_c384gdas_wav PASS
 
 
-baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/gsl-develop-20220808/INTEL/control_atm_aerosols
-working dir  = /scratch2/BMC/gsd-hpcs/Jacques.Middlecoff/joe_test_dir_delete_me/stmp2/Jacques.Middlecoff/FV3_RT/rt_277254/control_atm_aerosols
+baseline dir = /scratch2/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_atm_aerosols
+working dir  = /scratch1/NCEPDEV/stmp2/Samuel.Trahan/FV3_RT/rt_48937/control_atm_aerosols
 Checking test 137 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3822,12 +3822,10 @@ Checking test 137 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 286.277331
-  0: The maximum resident set size (KB)                   = 887888
+  0: The total amount of wall time                        = 288.508237
+  0: The maximum resident set size (KB)                   = 910772
 
 Test 137 control_atm_aerosols PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Thu Aug 11 19:24:25 UTC 2022
-Elapsed time: 01h:20m:38s. Have a nice day!

--- a/tests/RegressionTests_jet.intel.log
+++ b/tests/RegressionTests_jet.intel.log
@@ -1,26 +1,26 @@
-Fri Aug 12 19:09:59 GMT 2022
+Wed Aug 17 21:19:52 GMT 2022
 Start Regression test
 
 Compile 001 elapsed time 1771 seconds. -DAPP=S2SWA -DCCPP_SUITES=FV3_GFS_v16_coupled_nsstNoahmpUGWPv1,FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 002 elapsed time 336 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 003 elapsed time 1281 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 004 elapsed time 319 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 005 elapsed time 1434 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl,FV3_GFS_v17_p8_gf_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 006 elapsed time 1392 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 007 elapsed time 1309 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 008 elapsed time 322 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 009 elapsed time 288 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake,FV3_GFS_v17_p8_gf_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 010 elapsed time 290 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 011 elapsed time 291 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
-Compile 012 elapsed time 1777 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 013 elapsed time 1777 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 014 elapsed time 327 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
-Compile 015 elapsed time 150 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
-Compile 016 elapsed time 1564 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
-Compile 017 elapsed time 1357 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 002 elapsed time 292 seconds. -DAPP=S2SA -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 003 elapsed time 1323 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8,FV3_GFS_v17_p8_rrtmgp,FV3_GFS_v15_thompson_mynn_lam3km -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 004 elapsed time 295 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl -D32BIT=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 005 elapsed time 1392 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_RAP,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_HRRR,FV3_HRRR_smoke,FV3_RRFS_v1beta,FV3_RRFS_v1nssl,FV3_GFS_v17_p8_gf_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 006 elapsed time 1385 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_thompson,FV3_GFS_v16_noahmp -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 007 elapsed time 1278 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 008 elapsed time 392 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_GFS_v16,FV3_GFS_v16_csawmg,FV3_GFS_v16_flake,FV3_GFS_v16_ugwpv1,FV3_GFS_v16_ras,FV3_GFS_v16_noahmp,FV3_GFS_v16_thompson,FV3_GFS_v15_thompson_mynn,FV3_GFS_v17_p8 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 009 elapsed time 325 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP,FV3_RAP_cires_ugwp,FV3_RAP_unified_ugwp,FV3_RAP_flake,FV3_GFS_v17_p8_gf_mynn -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 010 elapsed time 387 seconds. -DAPP=ATM -DDEBUG=ON -DCCPP_SUITES=FV3_RAP_noah,FV3_RAP_RRTMGP,FV3_RAP_sfcdiff,FV3_RAP_noah_sfcdiff_cires_ugwp,FV3_RRFS_v1beta -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 011 elapsed time 270 seconds. -DAPP=ATM -DCCPP_SUITES=FV3_GFS_v16_fv3wam -D32BIT=ON -DMULTI_GASES=ON -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug
+Compile 012 elapsed time 1564 seconds. -DAPP=HAFSW -DMOVING_NEST=ON -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst,FV3_HAFS_v0_thompson_tedmf_gfdlsf -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 013 elapsed time 1759 seconds. -DAPP=HAFS-ALL -DCCPP_SUITES=FV3_HAFS_v0_gfdlmp_tedmf,FV3_HAFS_v0_gfdlmp_tedmf_nonsst -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 014 elapsed time 289 seconds. -DAPP=NG-GODAS -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON -DMOM6SOLO=ON
+Compile 015 elapsed time 147 seconds. -DAPP=NG-GODAS -DDEBUG=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Debug -DMOM6SOLO=ON
+Compile 016 elapsed time 1574 seconds. -DAPP=ATMW -DCCPP_SUITES=FV3_GFS_v16 -D32BIT=ON -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
+Compile 017 elapsed time 1441 seconds. -DAPP=ATMAERO -DCCPP_SUITES=FV3_GFS_v16 -DMPI=ON -DCMAKE_BUILD_TYPE=Release -DSIMDMULTIARCH=ON
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/cpld_control_p8
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/cpld_control_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/cpld_control_p8
 Checking test 001 cpld_control_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -86,14 +86,14 @@ Checking test 001 cpld_control_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 619.226720
-  0: The maximum resident set size (KB)                   = 1161456
+  0: The total amount of wall time                        = 566.265744
+  0: The maximum resident set size (KB)                   = 1157188
 
 Test 001 cpld_control_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/cpld_control_p8
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/cpld_2threads_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/cpld_2threads_p8
 Checking test 002 cpld_2threads_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -147,14 +147,14 @@ Checking test 002 cpld_2threads_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 1440.209798
-  0: The maximum resident set size (KB)                   = 1752364
+  0: The total amount of wall time                        = 1598.817918
+  0: The maximum resident set size (KB)                   = 1732740
 
 Test 002 cpld_2threads_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/cpld_control_p8
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/cpld_mpi_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/cpld_mpi_p8
 Checking test 003 cpld_mpi_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -208,14 +208,14 @@ Checking test 003 cpld_mpi_p8 results ....
  Comparing 20210323.060000.out_pnt.points .........OK
  Comparing 20210323.060000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 526.163566
-  0: The maximum resident set size (KB)                   = 1273924
+  0: The total amount of wall time                        = 904.198670
+  0: The maximum resident set size (KB)                   = 1290380
 
 Test 003 cpld_mpi_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/cpld_control_c96_p8
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/cpld_control_c96_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_c96_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/cpld_control_c96_p8
 Checking test 004 cpld_control_c96_p8 results ....
  Comparing sfcf021.tile1.nc .........OK
  Comparing sfcf021.tile2.nc .........OK
@@ -278,14 +278,14 @@ Checking test 004 cpld_control_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 520.900932
-  0: The maximum resident set size (KB)                   = 1281848
+  0: The total amount of wall time                        = 824.017134
+  0: The maximum resident set size (KB)                   = 1269816
 
 Test 004 cpld_control_c96_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/cpld_control_c96_p8
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/cpld_restart_c96_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_control_c96_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/cpld_restart_c96_p8
 Checking test 005 cpld_restart_c96_p8 results ....
  Comparing sfcf024.tile1.nc .........OK
  Comparing sfcf024.tile2.nc .........OK
@@ -336,14 +336,14 @@ Checking test 005 cpld_restart_c96_p8 results ....
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-23-21600.nc .........OK
 
-  0: The total amount of wall time                        = 246.142170
-  0: The maximum resident set size (KB)                   = 1237368
+  0: The total amount of wall time                        = 330.570262
+  0: The maximum resident set size (KB)                   = 1238428
 
 Test 005 cpld_restart_c96_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/cpld_debug_p8
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/cpld_debug_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/cpld_debug_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/cpld_debug_p8
 Checking test 006 cpld_debug_p8 results ....
  Comparing sfcf006.tile1.nc .........OK
  Comparing sfcf006.tile2.nc .........OK
@@ -394,14 +394,14 @@ Checking test 006 cpld_debug_p8 results ....
  Comparing RESTART/iced.2021-03-22-43200.nc .........OK
  Comparing RESTART/ufs.cpld.cpl.r.2021-03-22-43200.nc .........OK
 
-  0: The total amount of wall time                        = 1085.958840
-  0: The maximum resident set size (KB)                   = 1347404
+  0: The total amount of wall time                        = 1371.872595
+  0: The maximum resident set size (KB)                   = 1339544
 
 Test 006 cpld_debug_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control
 Checking test 007 control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -448,14 +448,14 @@ Checking test 007 control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 251.348474
-  0: The maximum resident set size (KB)                   = 471700
+  0: The total amount of wall time                        = 211.730068
+  0: The maximum resident set size (KB)                   = 469088
 
 Test 007 control PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_decomp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_decomp
 Checking test 008 control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -498,28 +498,28 @@ Checking test 008 control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 276.307025
-  0: The maximum resident set size (KB)                   = 470536
+  0: The total amount of wall time                        = 210.810972
+  0: The maximum resident set size (KB)                   = 469560
 
 Test 008 control_decomp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_2dwrtdecomp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_2dwrtdecomp
 Checking test 009 control_2dwrtdecomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 233.067999
-  0: The maximum resident set size (KB)                   = 471860
+  0: The total amount of wall time                        = 204.610761
+  0: The maximum resident set size (KB)                   = 470768
 
 Test 009 control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_2threads
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_2threads
 Checking test 010 control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -562,14 +562,14 @@ Checking test 010 control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 900.445676
- 0: The maximum resident set size (KB)                   = 525116
+ 0: The total amount of wall time                        = 857.484806
+ 0: The maximum resident set size (KB)                   = 523212
 
 Test 010 control_2threads PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_restart
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_restart
 Checking test 011 control_restart results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -608,14 +608,14 @@ Checking test 011 control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 116.643448
-  0: The maximum resident set size (KB)                   = 212132
+  0: The total amount of wall time                        = 104.966411
+  0: The maximum resident set size (KB)                   = 216692
 
 Test 011 control_restart PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_fhzero
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_fhzero
 Checking test 012 control_fhzero results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf021.nc ............ALT CHECK......OK
@@ -658,14 +658,14 @@ Checking test 012 control_fhzero results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 224.481887
-  0: The maximum resident set size (KB)                   = 470348
+  0: The total amount of wall time                        = 226.483327
+  0: The maximum resident set size (KB)                   = 467824
 
 Test 012 control_fhzero PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_CubedSphereGrid
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_CubedSphereGrid
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_CubedSphereGrid
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_CubedSphereGrid
 Checking test 013 control_CubedSphereGrid results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -692,14 +692,14 @@ Checking test 013 control_CubedSphereGrid results ....
  Comparing atmf024.tile5.nc .........OK
  Comparing atmf024.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 253.044716
-  0: The maximum resident set size (KB)                   = 467280
+  0: The total amount of wall time                        = 223.169877
+  0: The maximum resident set size (KB)                   = 471552
 
 Test 013 control_CubedSphereGrid PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_latlon
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_latlon
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_latlon
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_latlon
 Checking test 014 control_latlon results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -710,14 +710,14 @@ Checking test 014 control_latlon results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 282.552828
-  0: The maximum resident set size (KB)                   = 468796
+  0: The total amount of wall time                        = 217.544358
+  0: The maximum resident set size (KB)                   = 471984
 
 Test 014 control_latlon PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_wrtGauss_netcdf_parallel
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_wrtGauss_netcdf_parallel
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_wrtGauss_netcdf_parallel
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_wrtGauss_netcdf_parallel
 Checking test 015 control_wrtGauss_netcdf_parallel results ....
  Comparing sfcf000.nc ............ALT CHECK......OK
  Comparing sfcf024.nc .........OK
@@ -728,14 +728,14 @@ Checking test 015 control_wrtGauss_netcdf_parallel results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 233.795343
-  0: The maximum resident set size (KB)                   = 469064
+  0: The total amount of wall time                        = 234.794205
+  0: The maximum resident set size (KB)                   = 469608
 
 Test 015 control_wrtGauss_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_c48
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_c48
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_c48
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_c48
 Checking test 016 control_c48 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -774,14 +774,14 @@ Checking test 016 control_c48 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-0: The total amount of wall time                        = 572.405803
-0: The maximum resident set size (KB)                   = 670240
+0: The total amount of wall time                        = 565.580599
+0: The maximum resident set size (KB)                   = 671888
 
 Test 016 control_c48 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_c192
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_c192
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_c192
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_c192
 Checking test 017 control_c192 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -792,14 +792,14 @@ Checking test 017 control_c192 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 797.607726
-  0: The maximum resident set size (KB)                   = 567476
+  0: The total amount of wall time                        = 893.323225
+  0: The maximum resident set size (KB)                   = 568028
 
 Test 017 control_c192 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_c384
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_c384
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_c384
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_c384
 Checking test 018 control_c384 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -810,14 +810,14 @@ Checking test 018 control_c384 results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 1002.949533
-  0: The maximum resident set size (KB)                   = 695292
+  0: The total amount of wall time                        = 1024.649906
+  0: The maximum resident set size (KB)                   = 702472
 
 Test 018 control_c384 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_c384gdas
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_c384gdas
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_c384gdas
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_c384gdas
 Checking test 019 control_c384gdas results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -860,14 +860,14 @@ Checking test 019 control_c384gdas results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 1000.007681
-  0: The maximum resident set size (KB)                   = 807256
+  0: The total amount of wall time                        = 983.651662
+  0: The maximum resident set size (KB)                   = 795896
 
 Test 019 control_c384gdas PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_stochy
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_stochy
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_stochy
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_stochy
 Checking test 020 control_stochy results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -878,28 +878,28 @@ Checking test 020 control_stochy results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 194.542273
-  0: The maximum resident set size (KB)                   = 474400
+  0: The total amount of wall time                        = 277.093879
+  0: The maximum resident set size (KB)                   = 471680
 
 Test 020 control_stochy PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_stochy
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_stochy_restart
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_stochy
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_stochy_restart
 Checking test 021 control_stochy_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
  Comparing GFSFLX.GrbF12 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 73.866789
-  0: The maximum resident set size (KB)                   = 236548
+  0: The total amount of wall time                        = 127.562078
+  0: The maximum resident set size (KB)                   = 237040
 
 Test 021 control_stochy_restart PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_lndp
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_lndp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_lndp
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_lndp
 Checking test 022 control_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -910,14 +910,14 @@ Checking test 022 control_lndp results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 154.775115
-  0: The maximum resident set size (KB)                   = 471916
+  0: The total amount of wall time                        = 118.942375
+  0: The maximum resident set size (KB)                   = 477164
 
 Test 022 control_lndp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_iovr4
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_iovr4
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_iovr4
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_iovr4
 Checking test 023 control_iovr4 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -932,14 +932,14 @@ Checking test 023 control_iovr4 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 242.096260
-  0: The maximum resident set size (KB)                   = 470124
+  0: The total amount of wall time                        = 208.264196
+  0: The maximum resident set size (KB)                   = 471620
 
 Test 023 control_iovr4 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_iovr5
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_iovr5
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_iovr5
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_iovr5
 Checking test 024 control_iovr5 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -954,14 +954,14 @@ Checking test 024 control_iovr5 results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 261.571991
-  0: The maximum resident set size (KB)                   = 472036
+  0: The total amount of wall time                        = 208.506456
+  0: The maximum resident set size (KB)                   = 469464
 
 Test 024 control_iovr5 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_p8
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_p8
 Checking test 025 control_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1008,14 +1008,14 @@ Checking test 025 control_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 276.535433
-  0: The maximum resident set size (KB)                   = 851804
+  0: The total amount of wall time                        = 288.726601
+  0: The maximum resident set size (KB)                   = 854732
 
 Test 025 control_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_p8_lndp
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_p8_lndp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8_lndp
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_p8_lndp
 Checking test 026 control_p8_lndp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1034,14 +1034,14 @@ Checking test 026 control_p8_lndp results ....
  Comparing GFSPRS.GrbF24 .........OK
  Comparing GFSPRS.GrbF48 .........OK
 
-  0: The total amount of wall time                        = 546.676016
-  0: The maximum resident set size (KB)                   = 854460
+  0: The total amount of wall time                        = 825.431271
+  0: The maximum resident set size (KB)                   = 854612
 
 Test 026 control_p8_lndp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_p8
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_restart_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_restart_p8
 Checking test 027 control_restart_p8 results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -1080,14 +1080,14 @@ Checking test 027 control_restart_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 159.397913
-  0: The maximum resident set size (KB)                   = 601136
+  0: The total amount of wall time                        = 195.574376
+  0: The maximum resident set size (KB)                   = 599096
 
 Test 027 control_restart_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_p8
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_decomp_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_decomp_p8
 Checking test 028 control_decomp_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1130,14 +1130,14 @@ Checking test 028 control_decomp_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 273.591045
-  0: The maximum resident set size (KB)                   = 852420
+  0: The total amount of wall time                        = 538.872321
+  0: The maximum resident set size (KB)                   = 853168
 
 Test 028 control_decomp_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_p8
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_2threads_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_2threads_p8
 Checking test 029 control_2threads_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -1180,14 +1180,14 @@ Checking test 029 control_2threads_p8 results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 922.165997
- 0: The maximum resident set size (KB)                   = 933192
+ 0: The total amount of wall time                        = 1171.069523
+ 0: The maximum resident set size (KB)                   = 939140
 
 Test 029 control_2threads_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_p8_rrtmgp
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_p8_rrtmgp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8_rrtmgp
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_p8_rrtmgp
 Checking test 030 control_p8_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -1234,14 +1234,14 @@ Checking test 030 control_p8_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 353.608491
-  0: The maximum resident set size (KB)                   = 968968
+  0: The total amount of wall time                        = 573.061979
+  0: The maximum resident set size (KB)                   = 972088
 
 Test 030 control_p8_rrtmgp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/fv3_regional_control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/regional_control
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/regional_control
 Checking test 031 regional_control results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1252,42 +1252,42 @@ Checking test 031 regional_control results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 559.475726
- 0: The maximum resident set size (KB)                   = 582264
+ 0: The total amount of wall time                        = 924.114756
+ 0: The maximum resident set size (KB)                   = 581032
 
 Test 031 regional_control PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/fv3_regional_control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/regional_restart
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/regional_restart
 Checking test 032 regional_restart results ....
  Comparing dynf024.nc .........OK
  Comparing phyf024.nc .........OK
  Comparing PRSLEV.GrbF24 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 309.267560
- 0: The maximum resident set size (KB)                   = 583232
+ 0: The total amount of wall time                        = 324.526859
+ 0: The maximum resident set size (KB)                   = 579824
 
 Test 032 regional_restart PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/fv3_regional_control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/regional_control_2dwrtdecomp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/regional_control_2dwrtdecomp
 Checking test 033 regional_control_2dwrtdecomp results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 577.642575
- 0: The maximum resident set size (KB)                   = 580196
+ 0: The total amount of wall time                        = 856.447825
+ 0: The maximum resident set size (KB)                   = 580924
 
 Test 033 regional_control_2dwrtdecomp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/fv3_regional_noquilt
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/regional_noquilt
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_noquilt
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/regional_noquilt
 Checking test 034 regional_noquilt results ....
  Comparing atmos_4xdaily.nc .........OK
  Comparing fv3_history2d.nc .........OK
@@ -1295,14 +1295,14 @@ Checking test 034 regional_noquilt results ....
  Comparing RESTART/fv_core.res.tile1_new.nc .........OK
  Comparing RESTART/fv_tracer.res.tile1_new.nc .........OK
 
- 0: The total amount of wall time                        = 570.113439
- 0: The maximum resident set size (KB)                   = 588500
+ 0: The total amount of wall time                        = 977.646538
+ 0: The maximum resident set size (KB)                   = 590164
 
 Test 034 regional_noquilt PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/fv3_regional_control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/regional_2threads
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/regional_2threads
 Checking test 035 regional_2threads results ....
  Comparing dynf000.nc .........OK
  Comparing dynf024.nc .........OK
@@ -1313,28 +1313,28 @@ Checking test 035 regional_2threads results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF24 .........OK
 
- 0: The total amount of wall time                        = 2566.469323
- 0: The maximum resident set size (KB)                   = 582876
+ 0: The total amount of wall time                        = 2527.866681
+ 0: The maximum resident set size (KB)                   = 583064
 
 Test 035 regional_2threads PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/fv3_regional_netcdf_parallel
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/regional_netcdf_parallel
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_netcdf_parallel
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/regional_netcdf_parallel
 Checking test 036 regional_netcdf_parallel results ....
  Comparing dynf000.nc .........OK
- Comparing dynf024.nc ............ALT CHECK......OK
+ Comparing dynf024.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf024.nc .........OK
 
- 0: The total amount of wall time                        = 578.081612
- 0: The maximum resident set size (KB)                   = 580848
+ 0: The total amount of wall time                        = 870.398625
+ 0: The maximum resident set size (KB)                   = 578732
 
 Test 036 regional_netcdf_parallel PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/fv3_regional_3km
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/regional_3km
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_3km
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/regional_3km
 Checking test 037 regional_3km results ....
  Comparing dynf000.nc .........OK
  Comparing dynf006.nc .........OK
@@ -1345,28 +1345,28 @@ Checking test 037 regional_3km results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 513.918057
-  0: The maximum resident set size (KB)                   = 622980
+  0: The total amount of wall time                        = 507.100257
+  0: The maximum resident set size (KB)                   = 622176
 
 Test 037 regional_3km PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hrrr_control_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hrrr_control_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hrrr_control_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hrrr_control_debug
 Checking test 038 hrrr_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 346.557688
-  0: The maximum resident set size (KB)                   = 992972
+  0: The total amount of wall time                        = 423.001890
+  0: The maximum resident set size (KB)                   = 993644
 
 Test 038 hrrr_control_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_control
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_control
 Checking test 039 rap_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1413,14 +1413,14 @@ Checking test 039 rap_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 626.329440
-  0: The maximum resident set size (KB)                   = 837520
+  0: The total amount of wall time                        = 1069.139989
+  0: The maximum resident set size (KB)                   = 840416
 
 Test 039 rap_control PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_rrtmgp
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_rrtmgp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_rrtmgp
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_rrtmgp
 Checking test 040 rap_rrtmgp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1467,14 +1467,14 @@ Checking test 040 rap_rrtmgp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 672.792910
-  0: The maximum resident set size (KB)                   = 960764
+  0: The total amount of wall time                        = 1080.136347
+  0: The maximum resident set size (KB)                   = 954308
 
 Test 040 rap_rrtmgp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/regional_spp_sppt_shum_skeb
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/regional_spp_sppt_shum_skeb
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/regional_spp_sppt_shum_skeb
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/regional_spp_sppt_shum_skeb
 Checking test 041 regional_spp_sppt_shum_skeb results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
@@ -1485,14 +1485,14 @@ Checking test 041 regional_spp_sppt_shum_skeb results ....
  Comparing NATLEV.GrbF00 .........OK
  Comparing NATLEV.GrbF01 .........OK
 
-  0: The total amount of wall time                        = 1394.832648
-  0: The maximum resident set size (KB)                   = 1199496
+  0: The total amount of wall time                        = 1626.179521
+  0: The maximum resident set size (KB)                   = 1199684
 
 Test 041 regional_spp_sppt_shum_skeb PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_decomp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_decomp
 Checking test 042 rap_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1539,14 +1539,14 @@ Checking test 042 rap_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 647.559096
-  0: The maximum resident set size (KB)                   = 837316
+  0: The total amount of wall time                        = 1063.409827
+  0: The maximum resident set size (KB)                   = 838904
 
 Test 042 rap_decomp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_2threads
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_2threads
 Checking test 043 rap_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1593,14 +1593,14 @@ Checking test 043 rap_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 2324.841767
- 0: The maximum resident set size (KB)                   = 909036
+ 0: The total amount of wall time                        = 2499.167716
+ 0: The maximum resident set size (KB)                   = 902540
 
 Test 043 rap_2threads PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_restart
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_restart
 Checking test 044 rap_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1639,14 +1639,14 @@ Checking test 044 rap_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 464.073963
-  0: The maximum resident set size (KB)                   = 589396
+  0: The total amount of wall time                        = 606.938587
+  0: The maximum resident set size (KB)                   = 594840
 
 Test 044 rap_restart PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_sfcdiff
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_sfcdiff
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_sfcdiff
 Checking test 045 rap_sfcdiff results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1693,14 +1693,14 @@ Checking test 045 rap_sfcdiff results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 620.553883
-  0: The maximum resident set size (KB)                   = 839808
+  0: The total amount of wall time                        = 1050.654601
+  0: The maximum resident set size (KB)                   = 841652
 
 Test 045 rap_sfcdiff PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_sfcdiff
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_sfcdiff_decomp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_sfcdiff_decomp
 Checking test 046 rap_sfcdiff_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1747,14 +1747,14 @@ Checking test 046 rap_sfcdiff_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 638.462251
-  0: The maximum resident set size (KB)                   = 844076
+  0: The total amount of wall time                        = 1099.117547
+  0: The maximum resident set size (KB)                   = 843408
 
 Test 046 rap_sfcdiff_decomp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_sfcdiff
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_sfcdiff_restart
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_sfcdiff
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_sfcdiff_restart
 Checking test 047 rap_sfcdiff_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -1793,14 +1793,14 @@ Checking test 047 rap_sfcdiff_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 453.368256
-  0: The maximum resident set size (KB)                   = 591524
+  0: The total amount of wall time                        = 513.701192
+  0: The maximum resident set size (KB)                   = 592488
 
 Test 047 rap_sfcdiff_restart PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hrrr_control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hrrr_control
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hrrr_control
 Checking test 048 hrrr_control results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1847,14 +1847,14 @@ Checking test 048 hrrr_control results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 584.382444
-  0: The maximum resident set size (KB)                   = 837596
+  0: The total amount of wall time                        = 1022.719756
+  0: The maximum resident set size (KB)                   = 835132
 
 Test 048 hrrr_control PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hrrr_control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hrrr_control_decomp
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hrrr_control_decomp
 Checking test 049 hrrr_control_decomp results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1901,14 +1901,14 @@ Checking test 049 hrrr_control_decomp results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 621.218151
-  0: The maximum resident set size (KB)                   = 830608
+  0: The total amount of wall time                        = 1057.658374
+  0: The maximum resident set size (KB)                   = 840200
 
 Test 049 hrrr_control_decomp PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hrrr_control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hrrr_control_2threads
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hrrr_control_2threads
 Checking test 050 hrrr_control_2threads results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -1955,14 +1955,14 @@ Checking test 050 hrrr_control_2threads results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 2047.056314
- 0: The maximum resident set size (KB)                   = 902128
+ 0: The total amount of wall time                        = 2430.980775
+ 0: The maximum resident set size (KB)                   = 902468
 
 Test 050 hrrr_control_2threads PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hrrr_control
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hrrr_control_restart
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hrrr_control
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hrrr_control_restart
 Checking test 051 hrrr_control_restart results ....
  Comparing sfcf012.nc .........OK
  Comparing atmf012.nc .........OK
@@ -2001,14 +2001,14 @@ Checking test 051 hrrr_control_restart results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 441.326772
-  0: The maximum resident set size (KB)                   = 582748
+  0: The total amount of wall time                        = 486.340401
+  0: The maximum resident set size (KB)                   = 581444
 
 Test 051 hrrr_control_restart PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rrfs_v1beta
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rrfs_v1beta
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_v1beta
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rrfs_v1beta
 Checking test 052 rrfs_v1beta results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2055,14 +2055,14 @@ Checking test 052 rrfs_v1beta results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 609.939146
-  0: The maximum resident set size (KB)                   = 831872
+  0: The total amount of wall time                        = 1046.862085
+  0: The maximum resident set size (KB)                   = 833340
 
 Test 052 rrfs_v1beta PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rrfs_v1nssl
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rrfs_v1nssl
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_v1nssl
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rrfs_v1nssl
 Checking test 053 rrfs_v1nssl results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf009.nc .........OK
@@ -2077,14 +2077,14 @@ Checking test 053 rrfs_v1nssl results ....
  Comparing GFSPRS.GrbF09 .........OK
  Comparing GFSPRS.GrbF12 .........OK
 
-  0: The total amount of wall time                        = 678.630685
-  0: The maximum resident set size (KB)                   = 527132
+  0: The total amount of wall time                        = 1079.771199
+  0: The maximum resident set size (KB)                   = 529624
 
 Test 053 rrfs_v1nssl PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rrfs_v1nssl_nohailnoccn
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rrfs_v1nssl_nohailnoccn
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_v1nssl_nohailnoccn
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rrfs_v1nssl_nohailnoccn
 Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2099,14 +2099,14 @@ Checking test 054 rrfs_v1nssl_nohailnoccn results ....
  Comparing GFSPRS.GrbF21 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 658.652206
-  0: The maximum resident set size (KB)                   = 516796
+  0: The total amount of wall time                        = 1079.917018
+  0: The maximum resident set size (KB)                   = 517860
 
 Test 054 rrfs_v1nssl_nohailnoccn PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rrfs_conus13km_hrrr_warm
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rrfs_conus13km_hrrr_warm
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rrfs_conus13km_hrrr_warm
 Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2115,14 +2115,14 @@ Checking test 055 rrfs_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 263.166514
-  0: The maximum resident set size (KB)                   = 658492
+  0: The total amount of wall time                        = 571.353410
+  0: The maximum resident set size (KB)                   = 661296
 
 Test 055 rrfs_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rrfs_conus13km_radar_tten_warm
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rrfs_conus13km_radar_tten_warm
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_conus13km_radar_tten_warm
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rrfs_conus13km_radar_tten_warm
 Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2131,14 +2131,14 @@ Checking test 056 rrfs_conus13km_radar_tten_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 262.751282
-  0: The maximum resident set size (KB)                   = 663796
+  0: The total amount of wall time                        = 590.035306
+  0: The maximum resident set size (KB)                   = 661628
 
 Test 056 rrfs_conus13km_radar_tten_warm PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rrfs_smoke_conus13km_hrrr_warm
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rrfs_smoke_conus13km_hrrr_warm
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_smoke_conus13km_hrrr_warm
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rrfs_smoke_conus13km_hrrr_warm
 Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
@@ -2147,14 +2147,14 @@ Checking test 057 rrfs_smoke_conus13km_hrrr_warm results ....
  Comparing atmf001.nc .........OK
  Comparing atmf002.nc .........OK
 
-  0: The total amount of wall time                        = 283.018668
-  0: The maximum resident set size (KB)                   = 672084
+  0: The total amount of wall time                        = 599.081356
+  0: The maximum resident set size (KB)                   = 678672
 
 Test 057 rrfs_smoke_conus13km_hrrr_warm PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_p8_gf_mynn_hfip
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_p8_gf_mynn_hfip
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8_gf_mynn_hfip
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_p8_gf_mynn_hfip
 Checking test 058 control_p8_gf_mynn_hfip results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf021.nc .........OK
@@ -2201,14 +2201,14 @@ Checking test 058 control_p8_gf_mynn_hfip results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 397.723012
-  0: The maximum resident set size (KB)                   = 862864
+  0: The total amount of wall time                        = 777.138037
+  0: The maximum resident set size (KB)                   = 861548
 
 Test 058 control_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_p8_gf_mynn_hfip
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_decomp_p8_gf_mynn_hfip
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8_gf_mynn_hfip
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_decomp_p8_gf_mynn_hfip
 Checking test 059 control_decomp_p8_gf_mynn_hfip results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2251,14 +2251,14 @@ Checking test 059 control_decomp_p8_gf_mynn_hfip results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 404.289689
-  0: The maximum resident set size (KB)                   = 860096
+  0: The total amount of wall time                        = 775.972645
+  0: The maximum resident set size (KB)                   = 855936
 
 Test 059 control_decomp_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_p8_gf_mynn_hfip
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_2threads_p8_gf_mynn_hfip
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8_gf_mynn_hfip
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_2threads_p8_gf_mynn_hfip
 Checking test 060 control_2threads_p8_gf_mynn_hfip results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2301,14 +2301,14 @@ Checking test 060 control_2threads_p8_gf_mynn_hfip results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
- 0: The total amount of wall time                        = 1979.074119
- 0: The maximum resident set size (KB)                   = 940780
+ 0: The total amount of wall time                        = 1750.451474
+ 0: The maximum resident set size (KB)                   = 949148
 
 Test 060 control_2threads_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_p8_gf_mynn_hfip
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_restart_p8_gf_mynn_hfip
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_p8_gf_mynn_hfip
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_restart_p8_gf_mynn_hfip
 Checking test 061 control_restart_p8_gf_mynn_hfip results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
@@ -2347,14 +2347,14 @@ Checking test 061 control_restart_p8_gf_mynn_hfip results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 217.772917
-  0: The maximum resident set size (KB)                   = 611556
+  0: The total amount of wall time                        = 231.684889
+  0: The maximum resident set size (KB)                   = 614060
 
 Test 061 control_restart_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_csawmg
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_csawmg
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_csawmg
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_csawmg
 Checking test 062 control_csawmg results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2365,14 +2365,14 @@ Checking test 062 control_csawmg results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 479.626601
-  0: The maximum resident set size (KB)                   = 536300
+  0: The total amount of wall time                        = 846.104372
+  0: The maximum resident set size (KB)                   = 538576
 
 Test 062 control_csawmg PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_csawmgt
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_csawmgt
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_csawmgt
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_csawmgt
 Checking test 063 control_csawmgt results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2383,14 +2383,14 @@ Checking test 063 control_csawmgt results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 463.666891
-  0: The maximum resident set size (KB)                   = 539480
+  0: The total amount of wall time                        = 864.795230
+  0: The maximum resident set size (KB)                   = 539416
 
 Test 063 control_csawmgt PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_flake
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_flake
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_flake
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_flake
 Checking test 064 control_flake results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2401,14 +2401,14 @@ Checking test 064 control_flake results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 322.572519
-  0: The maximum resident set size (KB)                   = 541568
+  0: The total amount of wall time                        = 482.129363
+  0: The maximum resident set size (KB)                   = 540116
 
 Test 064 control_flake PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_ras
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_ras
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_ras
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_ras
 Checking test 065 control_ras results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2419,14 +2419,14 @@ Checking test 065 control_ras results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 256.975239
-  0: The maximum resident set size (KB)                   = 499352
+  0: The total amount of wall time                        = 337.162750
+  0: The maximum resident set size (KB)                   = 497464
 
 Test 065 control_ras PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_thompson
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_thompson
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_thompson
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_thompson
 Checking test 066 control_thompson results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2437,14 +2437,14 @@ Checking test 066 control_thompson results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 329.822031
-  0: The maximum resident set size (KB)                   = 849716
+  0: The total amount of wall time                        = 449.096298
+  0: The maximum resident set size (KB)                   = 850372
 
 Test 066 control_thompson PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_thompson_no_aero
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_thompson_no_aero
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_thompson_no_aero
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_thompson_no_aero
 Checking test 067 control_thompson_no_aero results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -2455,54 +2455,54 @@ Checking test 067 control_thompson_no_aero results ....
  Comparing GFSPRS.GrbF00 .........OK
  Comparing GFSPRS.GrbF24 .........OK
 
-  0: The total amount of wall time                        = 321.671767
-  0: The maximum resident set size (KB)                   = 847540
+  0: The total amount of wall time                        = 443.146405
+  0: The maximum resident set size (KB)                   = 844960
 
 Test 067 control_thompson_no_aero PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_wam
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_wam
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_wam
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_wam
 Checking test 068 control_wam results ....
  Comparing sfcf024.nc .........OK
  Comparing atmf024.nc .........OK
 
-  0: The total amount of wall time                        = 167.611354
-  0: The maximum resident set size (KB)                   = 233180
+  0: The total amount of wall time                        = 160.854567
+  0: The maximum resident set size (KB)                   = 235896
 
 Test 068 control_wam PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_debug
 Checking test 069 control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 197.442377
-  0: The maximum resident set size (KB)                   = 626596
+  0: The total amount of wall time                        = 209.835843
+  0: The maximum resident set size (KB)                   = 629032
 
 Test 069 control_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_2threads_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_2threads_debug
 Checking test 070 control_2threads_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
- 0: The total amount of wall time                        = 373.723089
- 0: The maximum resident set size (KB)                   = 676532
+ 0: The total amount of wall time                        = 416.689731
+ 0: The maximum resident set size (KB)                   = 678124
 
 Test 070 control_2threads_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_CubedSphereGrid_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_CubedSphereGrid_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_CubedSphereGrid_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_CubedSphereGrid_debug
 Checking test 071 control_CubedSphereGrid_debug results ....
  Comparing sfcf000.tile1.nc .........OK
  Comparing sfcf000.tile2.nc .........OK
@@ -2529,475 +2529,475 @@ Checking test 071 control_CubedSphereGrid_debug results ....
  Comparing atmf001.tile5.nc .........OK
  Comparing atmf001.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 215.004039
-  0: The maximum resident set size (KB)                   = 624640
+  0: The total amount of wall time                        = 234.945139
+  0: The maximum resident set size (KB)                   = 629200
 
 Test 071 control_CubedSphereGrid_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_wrtGauss_netcdf_parallel_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_wrtGauss_netcdf_parallel_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_wrtGauss_netcdf_parallel_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_wrtGauss_netcdf_parallel_debug
 Checking test 072 control_wrtGauss_netcdf_parallel_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc ............ALT CHECK......OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 200.291511
-  0: The maximum resident set size (KB)                   = 629496
+  0: The total amount of wall time                        = 239.961956
+  0: The maximum resident set size (KB)                   = 627088
 
 Test 072 control_wrtGauss_netcdf_parallel_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_stochy_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_stochy_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_stochy_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_stochy_debug
 Checking test 073 control_stochy_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 231.448594
-  0: The maximum resident set size (KB)                   = 634920
+  0: The total amount of wall time                        = 228.276582
+  0: The maximum resident set size (KB)                   = 632324
 
 Test 073 control_stochy_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_lndp_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_lndp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_lndp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_lndp_debug
 Checking test 074 control_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 231.976144
-  0: The maximum resident set size (KB)                   = 634016
+  0: The total amount of wall time                        = 206.694651
+  0: The maximum resident set size (KB)                   = 633052
 
 Test 074 control_lndp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_csawmg_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_csawmg_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_csawmg_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_csawmg_debug
 Checking test 075 control_csawmg_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 415.806385
-  0: The maximum resident set size (KB)                   = 671944
+  0: The total amount of wall time                        = 322.070867
+  0: The maximum resident set size (KB)                   = 669288
 
 Test 075 control_csawmg_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_csawmgt_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_csawmgt_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_csawmgt_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_csawmgt_debug
 Checking test 076 control_csawmgt_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 318.365933
-  0: The maximum resident set size (KB)                   = 667232
+  0: The total amount of wall time                        = 310.755651
+  0: The maximum resident set size (KB)                   = 668496
 
 Test 076 control_csawmgt_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_ras_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_ras_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_ras_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_ras_debug
 Checking test 077 control_ras_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 241.325200
-  0: The maximum resident set size (KB)                   = 639264
+  0: The total amount of wall time                        = 208.711218
+  0: The maximum resident set size (KB)                   = 638300
 
 Test 077 control_ras_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_diag_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_diag_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_diag_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_diag_debug
 Checking test 078 control_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 250.726848
-  0: The maximum resident set size (KB)                   = 684368
+  0: The total amount of wall time                        = 215.106909
+  0: The maximum resident set size (KB)                   = 687960
 
 Test 078 control_diag_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_debug_p8
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_debug_p8
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_debug_p8
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_debug_p8
 Checking test 079 control_debug_p8 results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 228.409510
-  0: The maximum resident set size (KB)                   = 1010536
+  0: The total amount of wall time                        = 225.641612
+  0: The maximum resident set size (KB)                   = 1016772
 
 Test 079 control_debug_p8 PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_thompson_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_thompson_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_thompson_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_thompson_debug
 Checking test 080 control_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 260.402355
-  0: The maximum resident set size (KB)                   = 986360
+  0: The total amount of wall time                        = 240.307360
+  0: The maximum resident set size (KB)                   = 991456
 
 Test 080 control_thompson_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_thompson_no_aero_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_thompson_no_aero_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_thompson_no_aero_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_thompson_no_aero_debug
 Checking test 081 control_thompson_no_aero_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 241.503830
-  0: The maximum resident set size (KB)                   = 980268
+  0: The total amount of wall time                        = 228.777489
+  0: The maximum resident set size (KB)                   = 979880
 
 Test 081 control_thompson_no_aero_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_thompson_debug_extdiag
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_thompson_extdiag_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_thompson_debug_extdiag
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_thompson_extdiag_debug
 Checking test 082 control_thompson_extdiag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 273.304030
-  0: The maximum resident set size (KB)                   = 1023212
+  0: The total amount of wall time                        = 249.131221
+  0: The maximum resident set size (KB)                   = 1017064
 
 Test 082 control_thompson_extdiag_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_thompson_progcld_thompson_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_thompson_progcld_thompson_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_thompson_progcld_thompson_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_thompson_progcld_thompson_debug
 Checking test 083 control_thompson_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 246.182114
-  0: The maximum resident set size (KB)                   = 989040
+  0: The total amount of wall time                        = 250.106485
+  0: The maximum resident set size (KB)                   = 990944
 
 Test 083 control_thompson_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/fv3_regional_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/regional_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/fv3_regional_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/regional_debug
 Checking test 084 regional_debug results ....
  Comparing dynf000.nc .........OK
  Comparing dynf001.nc .........OK
  Comparing phyf000.nc .........OK
  Comparing phyf001.nc .........OK
 
- 0: The total amount of wall time                        = 324.092213
- 0: The maximum resident set size (KB)                   = 609584
+ 0: The total amount of wall time                        = 333.211936
+ 0: The maximum resident set size (KB)                   = 609532
 
 Test 084 regional_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_control_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_control_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_control_debug
 Checking test 085 rap_control_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 359.326057
-  0: The maximum resident set size (KB)                   = 997320
+  0: The total amount of wall time                        = 387.792074
+  0: The maximum resident set size (KB)                   = 998532
 
 Test 085 rap_control_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_control_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_unified_drag_suite_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_control_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_unified_drag_suite_debug
 Checking test 086 rap_unified_drag_suite_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 355.884781
-  0: The maximum resident set size (KB)                   = 1001764
+  0: The total amount of wall time                        = 375.186625
+  0: The maximum resident set size (KB)                   = 1000180
 
 Test 086 rap_unified_drag_suite_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_diag_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_diag_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_diag_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_diag_debug
 Checking test 087 rap_diag_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 380.933588
-  0: The maximum resident set size (KB)                   = 1084936
+  0: The total amount of wall time                        = 385.062425
+  0: The maximum resident set size (KB)                   = 1084960
 
 Test 087 rap_diag_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_cires_ugwp_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_cires_ugwp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_cires_ugwp_debug
 Checking test 088 rap_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 364.885186
-  0: The maximum resident set size (KB)                   = 998064
+  0: The total amount of wall time                        = 391.371218
+  0: The maximum resident set size (KB)                   = 995992
 
 Test 088 rap_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_cires_ugwp_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_unified_ugwp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_cires_ugwp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_unified_ugwp_debug
 Checking test 089 rap_unified_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 368.446882
-  0: The maximum resident set size (KB)                   = 1001560
+  0: The total amount of wall time                        = 409.982279
+  0: The maximum resident set size (KB)                   = 997812
 
 Test 089 rap_unified_ugwp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_lndp_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_lndp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_lndp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_lndp_debug
 Checking test 090 rap_lndp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 362.462859
-  0: The maximum resident set size (KB)                   = 996844
+  0: The total amount of wall time                        = 368.043147
+  0: The maximum resident set size (KB)                   = 998444
 
 Test 090 rap_lndp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_flake_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_flake_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_flake_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_flake_debug
 Checking test 091 rap_flake_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 360.687555
-  0: The maximum resident set size (KB)                   = 1003248
+  0: The total amount of wall time                        = 419.820016
+  0: The maximum resident set size (KB)                   = 999904
 
 Test 091 rap_flake_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_progcld_thompson_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_progcld_thompson_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_progcld_thompson_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_progcld_thompson_debug
 Checking test 092 rap_progcld_thompson_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 362.655911
-  0: The maximum resident set size (KB)                   = 996988
+  0: The total amount of wall time                        = 363.603102
+  0: The maximum resident set size (KB)                   = 997304
 
 Test 092 rap_progcld_thompson_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_debug_p8_gf_mynn_hfip
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_debug_p8_gf_mynn_hfip
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_debug_p8_gf_mynn_hfip
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_debug_p8_gf_mynn_hfip
 Checking test 093 control_debug_p8_gf_mynn_hfip results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 338.386681
-  0: The maximum resident set size (KB)                   = 1025416
+  0: The total amount of wall time                        = 339.679830
+  0: The maximum resident set size (KB)                   = 1025816
 
 Test 093 control_debug_p8_gf_mynn_hfip PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_noah_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_noah_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_noah_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_noah_debug
 Checking test 094 rap_noah_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 363.499905
-  0: The maximum resident set size (KB)                   = 992364
+  0: The total amount of wall time                        = 361.606238
+  0: The maximum resident set size (KB)                   = 994468
 
 Test 094 rap_noah_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_rrtmgp_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_rrtmgp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_rrtmgp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_rrtmgp_debug
 Checking test 095 rap_rrtmgp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 601.819950
-  0: The maximum resident set size (KB)                   = 1115332
+  0: The total amount of wall time                        = 632.364207
+  0: The maximum resident set size (KB)                   = 1122964
 
 Test 095 rap_rrtmgp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_sfcdiff_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_sfcdiff_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_sfcdiff_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_sfcdiff_debug
 Checking test 096 rap_sfcdiff_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 351.834743
-  0: The maximum resident set size (KB)                   = 995304
+  0: The total amount of wall time                        = 365.071243
+  0: The maximum resident set size (KB)                   = 999808
 
 Test 096 rap_sfcdiff_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rap_noah_sfcdiff_cires_ugwp_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rap_noah_sfcdiff_cires_ugwp_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rap_noah_sfcdiff_cires_ugwp_debug
 Checking test 097 rap_noah_sfcdiff_cires_ugwp_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 588.186293
-  0: The maximum resident set size (KB)                   = 997916
+  0: The total amount of wall time                        = 625.247786
+  0: The maximum resident set size (KB)                   = 995192
 
 Test 097 rap_noah_sfcdiff_cires_ugwp_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/rrfs_v1beta_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/rrfs_v1beta_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/rrfs_v1beta_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/rrfs_v1beta_debug
 Checking test 098 rrfs_v1beta_debug results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf001.nc .........OK
  Comparing atmf000.nc .........OK
  Comparing atmf001.nc .........OK
 
-  0: The total amount of wall time                        = 361.352170
-  0: The maximum resident set size (KB)                   = 991584
+  0: The total amount of wall time                        = 360.813892
+  0: The maximum resident set size (KB)                   = 989304
 
 Test 098 rrfs_v1beta_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_wam_debug
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_wam_debug
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_wam_debug
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_wam_debug
 Checking test 099 control_wam_debug results ....
  Comparing sfcf019.nc .........OK
  Comparing atmf019.nc .........OK
 
-  0: The total amount of wall time                        = 371.337653
-  0: The maximum resident set size (KB)                   = 255904
+  0: The total amount of wall time                        = 401.379447
+  0: The maximum resident set size (KB)                   = 258324
 
 Test 099 control_wam_debug PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hafs_regional_atm
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hafs_regional_atm
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_atm
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hafs_regional_atm
 Checking test 100 hafs_regional_atm results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc ............ALT CHECK......OK
  Comparing HURPRS.GrbF06 .........OK
 
-  0: The total amount of wall time                        = 1330.432944
-  0: The maximum resident set size (KB)                   = 713372
+  0: The total amount of wall time                        = 1353.647913
+  0: The maximum resident set size (KB)                   = 717820
 
 Test 100 hafs_regional_atm PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hafs_regional_atm_thompson_gfdlsf
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hafs_regional_atm_thompson_gfdlsf
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_atm_thompson_gfdlsf
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hafs_regional_atm_thompson_gfdlsf
 Checking test 101 hafs_regional_atm_thompson_gfdlsf results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
 
-  0: The total amount of wall time                        = 1469.683179
-  0: The maximum resident set size (KB)                   = 1073832
+  0: The total amount of wall time                        = 1424.473792
+  0: The maximum resident set size (KB)                   = 1068128
 
 Test 101 hafs_regional_atm_thompson_gfdlsf PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hafs_regional_atm_ocn
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hafs_regional_atm_ocn
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_atm_ocn
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hafs_regional_atm_ocn
 Checking test 102 hafs_regional_atm_ocn results ....
- Comparing atmf006.nc ............ALT CHECK......OK
+ Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing ufs.hafs.cpl.hi.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 534.342458
-  0: The maximum resident set size (KB)                   = 750176
+  0: The total amount of wall time                        = 654.167665
+  0: The maximum resident set size (KB)                   = 749324
 
 Test 102 hafs_regional_atm_ocn PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hafs_regional_atm_wav
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hafs_regional_atm_wav
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_atm_wav
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hafs_regional_atm_wav
 Checking test 103 hafs_regional_atm_wav results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 1303.365996
-  0: The maximum resident set size (KB)                   = 738896
+  0: The total amount of wall time                        = 1278.682148
+  0: The maximum resident set size (KB)                   = 740720
 
 Test 103 hafs_regional_atm_wav PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hafs_regional_atm_ocn_wav
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hafs_regional_atm_ocn_wav
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_atm_ocn_wav
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hafs_regional_atm_ocn_wav
 Checking test 104 hafs_regional_atm_ocn_wav results ....
- Comparing atmf006.nc .........OK
+ Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
  Comparing archv.2019_241_06.a .........OK
  Comparing archs.2019_241_06.a .........OK
  Comparing out_grd.ww3 .........OK
  Comparing out_pnt.ww3 .........OK
 
-  0: The total amount of wall time                        = 1392.812183
-  0: The maximum resident set size (KB)                   = 765184
+  0: The total amount of wall time                        = 1342.197084
+  0: The maximum resident set size (KB)                   = 758376
 
 Test 104 hafs_regional_atm_ocn_wav PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hafs_regional_docn
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hafs_regional_docn
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_docn
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hafs_regional_docn
 Checking test 105 hafs_regional_docn results ....
  Comparing atmf006.nc .........OK
  Comparing sfcf006.nc .........OK
@@ -3005,14 +3005,14 @@ Checking test 105 hafs_regional_docn results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 515.758661
-  0: The maximum resident set size (KB)                   = 770808
+  0: The total amount of wall time                        = 532.478179
+  0: The maximum resident set size (KB)                   = 771396
 
 Test 105 hafs_regional_docn PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hafs_regional_docn_oisst
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hafs_regional_docn_oisst
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_docn_oisst
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hafs_regional_docn_oisst
 Checking test 106 hafs_regional_docn_oisst results ....
  Comparing atmf006.nc ............ALT CHECK......OK
  Comparing sfcf006.nc .........OK
@@ -3020,118 +3020,118 @@ Checking test 106 hafs_regional_docn_oisst results ....
  Comparing ufs.hafs.cpl.r.2019-08-29-21600.nc .........OK
  Comparing ufs.hafs.docn.r.2019-08-29-21600.nc .........OK
 
-  0: The total amount of wall time                        = 516.186822
-  0: The maximum resident set size (KB)                   = 740356
+  0: The total amount of wall time                        = 597.916789
+  0: The maximum resident set size (KB)                   = 746516
 
 Test 106 hafs_regional_docn_oisst PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/hafs_regional_datm_cdeps
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/hafs_regional_datm_cdeps
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/hafs_regional_datm_cdeps
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/hafs_regional_datm_cdeps
 Checking test 107 hafs_regional_datm_cdeps results ....
  Comparing ufs.hafs.cpl.hi.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.cpl.r.2019-08-30-00000.nc .........OK
  Comparing ufs.hafs.datm.r.2019-08-30-00000.nc .........OK
 
-  0: The total amount of wall time                        = 1433.914575
-  0: The maximum resident set size (KB)                   = 846780
+  0: The total amount of wall time                        = 1473.644303
+  0: The maximum resident set size (KB)                   = 846236
 
 Test 107 hafs_regional_datm_cdeps PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_control_cfsr
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_control_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_control_cfsr
 Checking test 108 datm_cdeps_control_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 214.255574
- 0: The maximum resident set size (KB)                   = 726992
+ 0: The total amount of wall time                        = 253.381624
+ 0: The maximum resident set size (KB)                   = 724984
 
 Test 108 datm_cdeps_control_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_control_cfsr
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_restart_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_restart_cfsr
 Checking test 109 datm_cdeps_restart_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 121.490192
- 0: The maximum resident set size (KB)                   = 725968
+ 0: The total amount of wall time                        = 156.563382
+ 0: The maximum resident set size (KB)                   = 724416
 
 Test 109 datm_cdeps_restart_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_control_gefs
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_control_gefs
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_control_gefs
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_control_gefs
 Checking test 110 datm_cdeps_control_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 199.111562
- 0: The maximum resident set size (KB)                   = 623104
+ 0: The total amount of wall time                        = 230.336760
+ 0: The maximum resident set size (KB)                   = 626792
 
 Test 110 datm_cdeps_control_gefs PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_iau_gefs
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_iau_gefs
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_iau_gefs
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_iau_gefs
 Checking test 111 datm_cdeps_iau_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 207.837554
- 0: The maximum resident set size (KB)                   = 624636
+ 0: The total amount of wall time                        = 221.291083
+ 0: The maximum resident set size (KB)                   = 629320
 
 Test 111 datm_cdeps_iau_gefs PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_stochy_gefs
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_stochy_gefs
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_stochy_gefs
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_stochy_gefs
 Checking test 112 datm_cdeps_stochy_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 207.676487
- 0: The maximum resident set size (KB)                   = 627080
+ 0: The total amount of wall time                        = 287.554752
+ 0: The maximum resident set size (KB)                   = 624400
 
 Test 112 datm_cdeps_stochy_gefs PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_bulk_cfsr
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_bulk_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_bulk_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_bulk_cfsr
 Checking test 113 datm_cdeps_bulk_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 223.922188
- 0: The maximum resident set size (KB)                   = 727912
+ 0: The total amount of wall time                        = 224.055120
+ 0: The maximum resident set size (KB)                   = 725568
 
 Test 113 datm_cdeps_bulk_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_bulk_gefs
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_bulk_gefs
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_bulk_gefs
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_bulk_gefs
 Checking test 114 datm_cdeps_bulk_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 204.388960
- 0: The maximum resident set size (KB)                   = 625604
+ 0: The total amount of wall time                        = 223.950113
+ 0: The maximum resident set size (KB)                   = 628332
 
 Test 114 datm_cdeps_bulk_gefs PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_mx025_cfsr
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_mx025_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_mx025_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_mx025_cfsr
 Checking test 115 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3140,14 +3140,14 @@ Checking test 115 datm_cdeps_mx025_cfsr results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 518.619469
-  0: The maximum resident set size (KB)                   = 557364
+  0: The total amount of wall time                        = 483.712694
+  0: The maximum resident set size (KB)                   = 550640
 
 Test 115 datm_cdeps_mx025_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_mx025_gefs
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_mx025_gefs
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_mx025_gefs
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_mx025_gefs
 Checking test 116 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/MOM.res_1.nc .........OK
@@ -3156,64 +3156,64 @@ Checking test 116 datm_cdeps_mx025_gefs results ....
  Comparing RESTART/iced.2011-10-01-43200.nc .........OK
  Comparing RESTART/DATM_GEFS.cpl.r.2011-10-01-43200.nc .........OK
 
-  0: The total amount of wall time                        = 526.352637
-  0: The maximum resident set size (KB)                   = 526876
+  0: The total amount of wall time                        = 501.088591
+  0: The maximum resident set size (KB)                   = 527280
 
 Test 116 datm_cdeps_mx025_gefs PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_control_cfsr
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_multiple_files_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_control_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_multiple_files_cfsr
 Checking test 117 datm_cdeps_multiple_files_cfsr results ....
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 201.989860
- 0: The maximum resident set size (KB)                   = 724880
+ 0: The total amount of wall time                        = 219.080704
+ 0: The maximum resident set size (KB)                   = 727376
 
 Test 117 datm_cdeps_multiple_files_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_3072x1536_cfsr
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_3072x1536_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_3072x1536_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_3072x1536_cfsr
 Checking test 118 datm_cdeps_3072x1536_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-02-00000.nc .........OK
  Comparing RESTART/DATM_CFSR3072x1536.cpl.r.2011-10-02-00000.nc .........OK
 
- 0: The total amount of wall time                        = 397.829605
- 0: The maximum resident set size (KB)                   = 1901212
+ 0: The total amount of wall time                        = 332.458931
+ 0: The maximum resident set size (KB)                   = 1899784
 
 Test 118 datm_cdeps_3072x1536_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_gfs
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_gfs
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_gfs
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_gfs
 Checking test 119 datm_cdeps_gfs results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2021-03-23-21600.nc .........OK
  Comparing RESTART/DATM_GFS.cpl.r.2021-03-23-21600.nc .........OK
 
- 0: The total amount of wall time                        = 394.066675
- 0: The maximum resident set size (KB)                   = 1898680
+ 0: The total amount of wall time                        = 323.351965
+ 0: The maximum resident set size (KB)                   = 1899720
 
 Test 119 datm_cdeps_gfs PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/datm_cdeps_debug_cfsr
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/datm_cdeps_debug_cfsr
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/datm_cdeps_debug_cfsr
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/datm_cdeps_debug_cfsr
 Checking test 120 datm_cdeps_debug_cfsr results ....
  Comparing RESTART/MOM.res.nc .........OK
  Comparing RESTART/iced.2011-10-01-21600.nc .........OK
  Comparing RESTART/DATM_CFSR.cpl.r.2011-10-01-21600.nc .........OK
 
- 0: The total amount of wall time                        = 579.207139
- 0: The maximum resident set size (KB)                   = 733692
+ 0: The total amount of wall time                        = 615.878726
+ 0: The maximum resident set size (KB)                   = 735532
 
 Test 120 datm_cdeps_debug_cfsr PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_atmwav
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_atmwav
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_atmwav
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_atmwav
 Checking test 121 control_atmwav results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf012.nc .........OK
@@ -3257,14 +3257,14 @@ Checking test 121 control_atmwav results ....
  Comparing RESTART/sfc_data.tile6.nc .........OK
  Comparing 20210322.180000.restart.glo_1deg .........OK
 
-  0: The total amount of wall time                        = 239.962876
-  0: The maximum resident set size (KB)                   = 487340
+  0: The total amount of wall time                        = 147.976584
+  0: The maximum resident set size (KB)                   = 492704
 
 Test 121 control_atmwav PASS
 
 
-baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220809/INTEL/control_atm_aerosols
-working dir  = /mnt/lfs4/BMC/gsd-fv3-dev/jacques/joe_test_dir_delete_me/RT_RUNDIRS/Jacques.Middlecoff/FV3_RT/rt_228203/control_atm_aerosols
+baseline dir = /lfs4/BMC/wrfruc/RT/NEMSfv3gfs/HFIP2022-20220817/INTEL/control_atm_aerosols
+working dir  = /lfs4/HFIP/hfv3gfs/Samuel.Trahan/RT_RUNDIRS/Samuel.Trahan/FV3_RT/rt_20505/control_atm_aerosols
 Checking test 122 control_atm_aerosols results ....
  Comparing sfcf000.nc .........OK
  Comparing sfcf024.nc .........OK
@@ -3311,12 +3311,12 @@ Checking test 122 control_atm_aerosols results ....
  Comparing RESTART/sfc_data.tile5.nc .........OK
  Comparing RESTART/sfc_data.tile6.nc .........OK
 
-  0: The total amount of wall time                        = 542.063256
-  0: The maximum resident set size (KB)                   = 916960
+  0: The total amount of wall time                        = 525.573047
+  0: The maximum resident set size (KB)                   = 915332
 
 Test 122 control_atm_aerosols PASS
 
 
 REGRESSION TEST WAS SUCCESSFUL
-Fri Aug 12 21:23:43 GMT 2022
-Elapsed time: 02h:13m:45s. Have a nice day!
+Thu Aug 18 00:31:06 GMT 2022
+Elapsed time: 03h:11m:15s. Have a nice day!

--- a/tests/rt.sh
+++ b/tests/rt.sh
@@ -486,7 +486,7 @@ if [[ $TESTS_FILE =~ '35d' ]] || [[ $TESTS_FILE =~ 'weekly' ]]; then
   TEST_35D=true
 fi
 
-BL_DATE=20220808
+BL_DATE=20220817
 if [[ $MACHINE_ID = hera.* ]] || [[ $MACHINE_ID = orion.* ]] || [[ $MACHINE_ID = cheyenne.* ]] || [[ $MACHINE_ID = gaea.* ]] || [[ $MACHINE_ID = jet.* ]] || [[ $MACHINE_ID = s4.* ]]; then
   RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/HFIP2022-${BL_DATE}/${RT_COMPILER^^}}
 else

--- a/tests/rt_utils.sh
+++ b/tests/rt_utils.sh
@@ -481,11 +481,6 @@ rocoto_step() {
     #   Is it done?
     state=$($ROCOTOSTAT -w $ROCOTO_XML -d $ROCOTO_DB -s | grep 197001010000 | awk -F" " '{print $2}')
     echo "$state" > $ROCOTO_STATE
-    dead_compile=$($ROCOTOSTAT -w $ROCOTO_XML -d $ROCOTO_DB | grep compile_ | grep DEAD | head -1 | awk -F" " '{print $2}')
-    if [[ ! -z ${dead_compile} ]]; then
-        echo "y" | ${ROCOTOCOMPLETE} -w $ROCOTO_XML -d $ROCOTO_DB -m ${dead_compile}_tasks
-        ${ROCOTOCOMPLETE} -w $ROCOTO_XML -d $ROCOTO_DB -t ${dead_compile}
-    fi
 }
 
 rocoto_run() {

--- a/tests/run_compile.sh
+++ b/tests/run_compile.sh
@@ -23,6 +23,15 @@ write_fail_test() {
   exit 1
 }
 
+remove_fail_test() {
+    echo "Removing test failure flag file for compile_${COMPILE_NR}"
+    if [[ ${OPNREQ_TEST} == true ]] ; then
+        rm -f $PATHRT/fail_opnreq_compile_${COMPILE_NR}
+    else
+        rm -f $PATHRT/fail_compile_${COMPILE_NR}
+    fi
+}
+
 if [[ $# != 4 ]]; then
   echo "Usage: $0 PATHRT RUNDIR_ROOT MAKE_OPT COMPILE_NR"
   exit 1
@@ -35,11 +44,7 @@ export COMPILE_NR=$4
 
 cd ${PATHRT}
 OPNREQ_TEST=${OPNREQ_TEST:-false}
-if [[ ${OPNREQ_TEST} == true ]]; then
-  rm -f fail_opnreq_compile_${COMPILE_NR}
-else
-  rm -f fail_compile_${COMPILE_NR}
-fi
+remove_fail_test
 
 [[ -e ${RUNDIR_ROOT}/compile_${COMPILE_NR}.env ]] && source ${RUNDIR_ROOT}/compile_${COMPILE_NR}.env
 source default_vars.sh
@@ -85,6 +90,9 @@ ls -l ${PATHTR}/tests/fv3_${COMPILE_NR}.exe
 
 cp ${RUNDIR}/compile_*_time.log ${LOG_DIR}
 cat ${RUNDIR}/job_timestamp.txt >> ${LOG_DIR}/job_${JOB_NR}_timestamp.txt
+
+remove_fail_test
+
 ################################################################################
 # End compile job
 ################################################################################

--- a/tests/run_test.sh
+++ b/tests/run_test.sh
@@ -23,6 +23,15 @@ write_fail_test() {
   exit 1
 }
 
+remove_fail_test() {
+    echo "Removing test failure flag file for ${TEST_NAME} ${TEST_NR}"
+    if [[ ${OPNREQ_TEST} == true ]] ; then
+        rm -f $PATHRT/fail_opnreq_test_${TEST_NR}
+    else
+        rm -f $PATHRT/fail_test_${TEST_NR}
+    fi
+}
+
 function compute_petbounds() {
 
   # each test MUST define ${COMPONENT}_tasks variable for all components it is using
@@ -90,11 +99,7 @@ export COMPILE_NR=$5
 
 cd ${PATHRT}
 OPNREQ_TEST=${OPNREQ_TEST:-false}
-if [[ ${OPNREQ_TEST} == true ]]; then
-  rm -f fail_opnreq_test_${TEST_NR}
-else
-  rm -f fail_test_${TEST_NR}
-fi
+remove_fail_test
 
 [[ -e ${RUNDIR_ROOT}/run_test_${TEST_NR}.env ]] && source ${RUNDIR_ROOT}/run_test_${TEST_NR}.env
 source default_vars.sh
@@ -342,6 +347,9 @@ fi
 if [[ $SCHEDULER != 'none' ]]; then
   cat ${RUNDIR}/job_timestamp.txt >> ${LOG_DIR}/job_${JOB_NR}_timestamp.txt
 fi
+
+remove_fail_test
+
 ################################################################################
 # End test
 ################################################################################


### PR DESCRIPTION
# PR Checklist

- [ ] This PR is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR. Please consult the ufs-weather-model [wiki](https://github.com/ufs-community/ufs-weather-model/wiki/Making-code-changes-in-the-UFS-weather-model-and-its-subcomponents) if you are unsure how to do this.

- [ ] This PR has been tested using a branch which is up-to-date with the top of all sub-component repositories except for those sub-components which are the subject of this PR

- [ ] An Issue describing the work contained in this PR has been created either in the subcomponent(s) or in the ufs-weather-model. The Issue should be created in the repository that is most relevant to the changes in contained in the PR. The Issue and the dependent sub-component PR 
are specified below.

- [ ] Results for one or more of the regression tests change and the reasons for the changes are understood and explained below.

- [ ] New or updated input data is required by this PR. If checked, please work with the code managers to update input data sets on all platforms.

## Instructions: All subsequent sections of text should be filled in as appropriate.

The information provided below allows the code managers to understand the changes relevant to this PR, whether those changes are in the ufs-weather-model repository or in a subcomponent repository. Ufs-weather-model code managers will use the information provided to add any applicable labels, assign reviewers and place it in the Commit Queue. Once the PR is in the Commit Queue, it is the PR owner's responsiblity to keep the PR up-to-date with the develop branch of ufs-weather-model. 

## Description
- GF Changes
```
- Merra2 AOD read into GF, replaces assumed globally uniform AOD. This change is more realistic. 
- Removes edtmax and edtmin
- Removes double counting in sgscloud_radpre when GF is used
- Output updraft mass flux and precipitation includes the all elements of the tri-modal precipitation desciption (small, mid, and deep can co-exist in one grid point)
- Mass factor included in pwav, pwev, and pwavh. 
- psum, psumh is removed since that variable is the same as pwav, pwavh
- Assumed precipitation efficiency is increased
- Temperature and specific humidity input into is now updated by the previous parameterizations
- -z_detr increased to 1000
```


### Issue(s) addressed

Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues must always be created before starting work on a PR branch!) 
- fixes #<issue_number>
- fixes noaa-emc/fv3atm/issues/<issue_number>

## Testing

How were these changes tested? What compilers / HPCs was it tested with? Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Have regression tests and unit tests (utests) been run? On which platforms and with which compilers? (Note that unit tests can only be run on tier-1 platforms)

- [ ] hera.intel
- [ ] hera.gnu
- [ ] orion.intel
- [ ] cheyenne.intel 
- [ ] cheyenne.gnu
- [ ] gaea.intel 
- [ ] jet.intel
- [ ] wcoss_cray
- [ ] wcoss_dell_p3
- [ ] opnReqTest for newly added/changed feature
- [ ] CI

## Dependencies

If testing this branch requires non-default branches in other repositories, list them. Those branches should have matching names (ideally).

Do PRs in upstream repositories need to be merged first?
If so add the "waiting for other repos" label and list the upstream PRs
- waiting on https://github.com/NOAA-GSL/ccpp-physics/pull/159
- waiting on https://github.com/NOAA-GSL/fv3atm/pull/152
